### PR TITLE
fix(rpc): xratelimit_cache crash caused by race condition

### DIFF
--- a/src/xtopcom/xrpc/xratelimit/xratelimit_cache.cpp
+++ b/src/xtopcom/xrpc/xratelimit/xratelimit_cache.cpp
@@ -32,6 +32,7 @@ RatelimitCache::RatelimitCache(const RatelimitConfig* config)
 RatelimitCache::~RatelimitCache() {
     break_out_ = true;
     cv_.notify_all();
+    thread_.join();
     // ip_hashmap_.Foreach([](int, IpCheckContent * p) { delete p; });
     // account_hashmap_.Foreach([](std::string, AccountCheckContent * p) { delete p; });
 }

--- a/src/xtopcom/xrpc/xratelimit/xratelimit_cache.h
+++ b/src/xtopcom/xrpc/xratelimit/xratelimit_cache.h
@@ -94,11 +94,11 @@ private:
     IpHashMap ip_hashmap_;
     AccountHashMap account_hashmap_;
     bool break_out_{ false };
-    RatelimitThread thread_;
     std::mutex mutex_;
     std::condition_variable cv_;
     int64_t second_interval_{ 1 };
     uint64_t clean_overtime_s_{ 600 };
+    RatelimitThread thread_;
 };
 
 NS_END2

--- a/src/xtopcom/xrpc/xratelimit/xratelimit_thread.h
+++ b/src/xtopcom/xrpc/xratelimit/xratelimit_thread.h
@@ -30,8 +30,10 @@ public:
         : ThreadBase(func)
         , thread_(func_)
     {}
-    virtual ~RatelimitThread() {
-        thread_.join();
+    void join() {
+        if (thread_.joinable()) {
+            thread_.join();
+        }
     }
 
 private:


### PR DESCRIPTION
self test ok.  
call thread_.join in xratelimit_cache destructor directly, avoid thread_ access xratelimit_cache's members after their destruction.