### PR TITLE
fix crash when restart node

### DIFF
--- a/src/libraries/xapplication/src/xapplication.cpp
+++ b/src/libraries/xapplication/src/xapplication.cpp
@@ -276,12 +276,12 @@ bool xtop_application::create_genesis_account(std::string const & address, uint6
     // m_blockstore->delete_block(_vaddr, genesis_block.get());  // delete default genesis block
     auto ret = m_blockstore->store_block(_vaddr, genesis_block.get());
     if (!ret) {
-        xerror("xtop_application::create_genesis_account store genesis block fail");
+        xwarn("xtop_application::create_genesis_account store genesis block fail");
         return false;
     }
     ret = m_blockstore->execute_block(_vaddr, genesis_block.get());
     if (!ret) {
-        xerror("xtop_application::create_genesis_account execute genesis block fail");
+        xwarn("xtop_application::create_genesis_account execute genesis block fail");
         return false;
     }
     return true;

--- a/src/xtopcom/xblockstore/src/xvblockhub.cpp
+++ b/src/xtopcom/xblockstore/src/xvblockhub.cpp
@@ -1280,7 +1280,7 @@ namespace top
                     {
                         if(existing_block_flags != new_block_flags)
                             xwarn("xblockacct_t::cache_index,warn-try to overwrite newer block with flags(0x%x) by outdated block=%s",existing_block->get_block_flags(),this_block->dump().c_str());
-                        return false;
+                        return true;
                     }
                     //now combine flags
                     existing_block->reset_block_flags(existing_block_flags | (new_block_flags & base::enum_xvblock_flags_high4bit_mask));//merge flags(just for high4bit)


### PR DESCRIPTION
To avoid crash when restart node:
1. change xerror to xwarn to avoid crash directely because in some conditions, "return false" may not a fault. 
2. change "return false" to "return true" in "cache_index"
"existing_block_flags != new_block_flags" if the interface create existing genesis block, and finally return false as well as make error. We need to confirm that it is no problem that genesis block is existed when enter "cache_index". So in this case, we need to return true.
If the change ocurred, the differences is that:
firstly, we will write db again and cover old one;
secondly, i dont know exactly whether there exists other conditions to make "existing_block_flags != new_block_flags", and if the change will affect them.
thirdly, the source of function "cache_index" is totally different with the present version, so i cant neither figure out if it will affect other functions.


