### PR TITLE
feat(xdata): move unit block state update into blockchain2

### DIFF
--- a/src/xtopcom/xbasic/src/xserializable_based_on.cpp
+++ b/src/xtopcom/xbasic/src/xserializable_based_on.cpp
@@ -2,9 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "xbase/xcontext.h"
 #include "xbasic/xserializable_based_on.h"
+
+#include "xbase/xcontext.h"
+#include "xbase/xlog.h"
+#include "xbasic/xerror/xchain_error.h"
 #include "xbasic/xerror/xerror.h"
+#include "xbasic/xerror/xthrow_error.h"
 
 #include <cassert>
 
@@ -76,6 +80,98 @@ std::int32_t xtop_serializable_based_on<void>::serialize_from(base::xbuffer_t & 
         ec = top::error::xbasic_errc_t::deserialization_error;
     }
     return -1;
+}
+
+template <>
+xbyte_buffer_t xtop_serializable_based_on<void>::serialize_based_on<base::xstream_t>() const {
+    base::xstream_t stream{ base::xcontext_t::instance() };
+    if (do_write(stream) <= 0) {
+        std::error_code ec = top::error::xbasic_errc_t::serialization_error;
+        top::error::throw_error(ec);
+    }
+
+    return { stream.data(), stream.data() + static_cast<size_t>(stream.size()) };
+}
+
+template <>
+xbyte_buffer_t xtop_serializable_based_on<void>::serialize_based_on<base::xstream_t>(std::error_code & ec) const {
+    try {
+        return serialize_based_on<base::xstream_t>();
+    } catch (top::error::xchain_error_t const & eh) {
+        ec = eh.code();
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on serialize error category %s; msg %s", ec.category().name(), eh.what());
+#else
+        xerror("xserializable_based_on serialize error category %s; msg %s", ec.category().name(), eh.what());
+#endif
+    } catch (std::exception const & eh) {
+        ec = top::error::xbasic_errc_t::serialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on serialize error %s", eh.what());
+#else
+        xerror("xserializable_based_on serialize error %s", eh.what());
+#endif
+    } catch (enum_xerror_code const error_code) {
+        ec = top::error::xbasic_errc_t::serialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on serialize error code %d", static_cast<int>(error_code));
+#else
+        xerror("xserializable_based_on serialize error code %d", static_cast<int>(error_code));
+#endif
+    } catch (...) {
+        ec = top::error::xbasic_errc_t::serialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("%s", "xserializable_based_on serialize unknown error");
+#else
+        xerror("%s", "xserializable_based_on serialize unknown error");
+#endif
+    }
+
+    return {};
+}
+
+template <>
+void xtop_serializable_based_on<void>::deserialize_based_on<base::xstream_t>(xbyte_buffer_t bytes) {
+    base::xstream_t stream{ base::xcontext_t::instance(), bytes.data(), static_cast<uint32_t>(bytes.size()) };
+    if (do_read(stream) <= 0) {
+        std::error_code ec{ top::error::xbasic_errc_t::deserialization_error };
+        top::error::throw_error(ec);
+    }
+}
+
+template <>
+void xtop_serializable_based_on<void>::deserialize_based_on<base::xstream_t>(xbyte_buffer_t bytes, std::error_code & ec) {
+    try {
+        deserialize_based_on<base::xstream_t>(std::move(bytes));
+    } catch (top::error::xchain_error_t const & eh) {
+        ec = eh.code();
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on deserialize error category %s; msg %s", ec.category().name(), eh.what());
+#else
+        xerror("xserializable_based_on deserialize error category %s; msg %s", ec.category().name(), eh.what());
+#endif
+    } catch (std::exception const & eh) {
+        ec = top::error::xbasic_errc_t::deserialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on deserialize error %s", eh.what());
+#else
+        xerror("xserializable_based_on deserialize error %s", eh.what());
+#endif
+    } catch (enum_xerror_code const error_code) {
+        ec = top::error::xbasic_errc_t::deserialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on deserialize error code %d", static_cast<int>(error_code));
+#else
+        xerror("xserializable_based_on deserialize error code %d", static_cast<int>(error_code));
+#endif
+    } catch (...) {
+        ec = top::error::xbasic_errc_t::deserialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("%s", "xserializable_based_on deserialize unknown error");
+#else
+        xerror("%s", "xserializable_based_on deserialize unknown error");
+#endif
+    }
 }
 
 std::int32_t xtop_serializable_based_on<void>::do_write(base::xstream_t & stream, std::error_code & ec) const {

--- a/src/xtopcom/xbasic/xserializable_based_on.h
+++ b/src/xtopcom/xbasic/xserializable_based_on.h
@@ -27,6 +27,7 @@
 #endif
 
 #include "xbase/xns_macro.h"
+#include "xbasic/xbyte_buffer.h"
 
 #include <cstdint>
 #include <string>
@@ -103,6 +104,18 @@ public:
 
     std::int32_t serialize_from(base::xbuffer_t & stream, std::error_code & ec);
 
+    template <typename StreamT>
+    xbyte_buffer_t serialize_based_on() const;
+
+    template <typename StreamT>
+    xbyte_buffer_t serialize_based_on(std::error_code & ec) const;
+
+    template <typename StreamT>
+    void deserialize_based_on(xbyte_buffer_t bytes);
+
+    template <typename StreamT>
+    void deserialize_based_on(xbyte_buffer_t bytes, std::error_code & ec);
+
 protected:
     /**
      * @brief Serialize the object into the steam directly.
@@ -124,3 +137,18 @@ using xserializable_based_on = xtop_serializable_based_on<BasedOnT>;
 
 NS_END1
 
+NS_BEG1(top)
+
+template <>
+xbyte_buffer_t xtop_serializable_based_on<void>::serialize_based_on<base::xstream_t>() const;
+
+template <>
+xbyte_buffer_t xtop_serializable_based_on<void>::serialize_based_on<base::xstream_t>(std::error_code & ec) const;
+
+template <>
+void xtop_serializable_based_on<void>::deserialize_based_on<base::xstream_t>(xbyte_buffer_t bytes);
+
+template <>
+void xtop_serializable_based_on<void>::deserialize_based_on<base::xstream_t>(xbyte_buffer_t bytes, std::error_code & ec);
+
+NS_END1

--- a/src/xtopcom/xchain_upgrade/src/xchain_upgrade_center.cpp
+++ b/src/xtopcom/xchain_upgrade/src/xchain_upgrade_center.cpp
@@ -17,7 +17,7 @@ namespace top {
             xfork_point_t{xfork_point_type_t::logic_time, 3904920, "reward contract save reward detail"},
             xfork_point_t{xfork_point_type_t::logic_time, 3913560, "vote contract trx split fork point"},
             xfork_point_t{xfork_point_type_t::logic_time, 4000000, "rec standby update programe version"},
-            xfork_point_t{xfork_point_type_t::logic_time, 5000000, "slash and workload contract upgrade"}
+            xfork_point_t{xfork_point_type_t::logic_time, common::xjudgement_day, "slash and workload contract upgrade"}
         };
 
         // !!!change!!! fork time for galileo
@@ -27,7 +27,7 @@ namespace top {
             xfork_point_t{xfork_point_type_t::logic_time, 3904920, "reward contract save reward detail"},
             xfork_point_t{xfork_point_type_t::logic_time, 3913560, "vote contract trx split fork point"},
             xfork_point_t{xfork_point_type_t::logic_time, 4000000, "rec standby update programe version"},
-            xfork_point_t{xfork_point_type_t::logic_time, 5000000, "slash and workload contract upgrade"}
+            xfork_point_t{xfork_point_type_t::logic_time, common::xjudgement_day, "slash and workload contract upgrade"}
         };
 
         // !!!change!!! fork time for local develop net
@@ -37,7 +37,7 @@ namespace top {
             xfork_point_t{xfork_point_type_t::logic_time, 3904920, "reward contract save reward detail"},
             xfork_point_t{xfork_point_type_t::logic_time, 3913560, "vote contract trx split fork point"},
             xfork_point_t{xfork_point_type_t::logic_time, 4000000, "rec standby update programe version"},
-            xfork_point_t{xfork_point_type_t::logic_time, 5000000, "slash and workload contract upgrade"}
+            xfork_point_t{xfork_point_type_t::logic_time, common::xjudgement_day, "slash and workload contract upgrade"}
         };
 
         xchain_fork_config_t const & xtop_chain_fork_config_center::chain_fork_config() noexcept {

--- a/src/xtopcom/xcommon/xenable_execute_block.h
+++ b/src/xtopcom/xcommon/xenable_execute_block.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.#pragma once
+
+#pragma once
+
+#include "xbase/xobject_ptr.h"
+#include "xbasic/xerror/xthrow_error.h"
+#include "xdata/xblock.h"
+
+#include <system_error>
+
+NS_BEG2(top, common)
+
+template <class T, template <typename> class SmartPtrT>
+class xtop_enable_execute_block {
+public:
+    xtop_enable_execute_block() = default;
+    xtop_enable_execute_block(xtop_enable_execute_block const &) = delete;
+    xtop_enable_execute_block & operator=(xtop_enable_execute_block const &) = delete;
+    xtop_enable_execute_block(xtop_enable_execute_block &&) = default;
+    xtop_enable_execute_block & operator=(xtop_enable_execute_block &&) = default;
+    virtual ~xtop_enable_execute_block() = default;
+
+    /// @brief Apply block data onto current object of type T.
+    /// @param block The block object to be applied.
+    /// @param ec The error code that will be set in the execute process.
+    virtual void execute_block(SmartPtrT<data::xblock_t const> block, std::error_code & ec) = 0;
+
+    /// @brief Apply block data onto current object of type T.
+    ///        If any error is seen, top::error::xchain_error_t exception will be thrown.
+    /// @param block The block object ot be applied.
+    virtual void execute_block(SmartPtrT<data::xblock_t const> block) {
+        std::error_code ec;
+        execute_block(std::move(block), ec);
+        top::error::throw_error(ec);
+    }
+};
+
+template <class T, template <typename> class SmartPtrT = xobject_ptr_t>
+using xenable_execute_block_t = xtop_enable_execute_block<T, SmartPtrT>;
+
+NS_END2

--- a/src/xtopcom/xconfig/xpredefined_configurations.h
+++ b/src/xtopcom/xconfig/xpredefined_configurations.h
@@ -138,7 +138,6 @@ XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(max_vote_nodes_num, std::uint32_t, normal,
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(votes_report_interval, xinterval_t, normal, 10, 1, std::numeric_limits<xinterval_t>::max());
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(reward_issue_interval, xinterval_t, normal, 30, 1, std::numeric_limits<xinterval_t>::max());    // 10 minutes
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(workload_timer_interval, xinterval_t, normal, 20, 1, std::numeric_limits<xinterval_t>::max());  // 200 seconds
-XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(workload_collection_interval, xinterval_t, normal, 17, 1, std::numeric_limits<xinterval_t>::max());  // 180 seconds
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(min_node_reward, uint64_t, important, 100, 0, std::numeric_limits<uint64_t>::max());
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(min_voter_dividend, uint64_t, important, 100, 0, std::numeric_limits<uint64_t>::max());
 #else
@@ -151,11 +150,11 @@ XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(max_vote_nodes_num, std::uint32_t, normal,
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(votes_report_interval, xinterval_t, normal, 30, 1, std::numeric_limits<xinterval_t>::max());
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(reward_issue_interval, xinterval_t, normal, 8640, 1, std::numeric_limits<xinterval_t>::max());  // 24 hours
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(workload_timer_interval, xinterval_t, normal, 17, 1, std::numeric_limits<xinterval_t>::max());  // 180 seconds
-XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(workload_collection_interval, xinterval_t, normal, 17, 1, std::numeric_limits<xinterval_t>::max());  // 180 seconds
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(min_node_reward, uint64_t, important, 0, 0, std::numeric_limits<uint64_t>::max());
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(min_voter_dividend, uint64_t, important, 0, 0, std::numeric_limits<uint64_t>::max());
 #endif
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(tableworkload_report_schedule_interval, xinterval_t, important, 1, 1, std::numeric_limits<xinterval_t>::max());
+XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(workload_collection_interval, xinterval_t, normal, 18, 1, std::numeric_limits<xinterval_t>::max());
 // mainnet node active
 
 #if defined XBUILD_GALILEO

--- a/src/xtopcom/xdata/src/xerror.cpp
+++ b/src/xtopcom/xdata/src/xerror.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2017-2018 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "xdata/xerror/xerror.h"
+
+NS_BEG3(top, data, error)
+
+static char const * const errc_to_string(int code) {
+    auto const ec = static_cast<xerrc_t>(code);
+
+    switch (ec) {
+    case xerrc_t::ok:
+        return "ok";
+
+    case xerrc_t::update_state_failed:
+        return "update state failed";
+
+    case xerrc_t::update_state_block_height_mismatch:
+        return "update state failed due to mismatch block height";
+
+    case xerrc_t::update_state_block_type_mismatch:
+        return "update state failed due to mismatch block type";
+
+    default:
+        return "unknown data module error";
+    }
+}
+
+std::error_code make_error_code(xerrc_t const errc) noexcept {
+    return std::error_code(static_cast<int>(errc), data_category());
+}
+
+std::error_condition make_error_condition(xerrc_t const errc) noexcept {
+    return std::error_condition(static_cast<int>(errc), data_category());
+}
+
+class xtop_data_category final : public std::error_category {
+    char const * name() const noexcept override {
+        return "data";
+    }
+
+    std::string message(int errc) const override {
+        return errc_to_string(errc);
+    }
+};
+using xdata_category_t = xtop_data_category;
+
+std::error_category const & data_category() {
+    static xdata_category_t category{};
+    return category;
+}
+
+NS_END3

--- a/src/xtopcom/xdata/xblock.h
+++ b/src/xtopcom/xdata/xblock.h
@@ -12,8 +12,6 @@
 #if defined(__clang__)
 
 #    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wall"
-#    pragma clang diagnostic ignored "-Wextra"
 #    pragma clang diagnostic ignored "-Wpedantic"
 
 #elif defined(__GNUC__)

--- a/src/xtopcom/xdata/xblockchain.h
+++ b/src/xtopcom/xdata/xblockchain.h
@@ -5,14 +5,17 @@
 #pragma once
 
 #include <string>
-#include "xdata/xblock.h"
+
 #include "xbase/xobject_ptr.h"
+#include "xcommon/xenable_execute_block.h"
 #include "xdata/xaccount_mstate.h"
+#include "xdata/xblock.h"
 #include "xdata/xtransaction.h"
 
 NS_BEG2(top, data)
 
-class xblockchain2_t : public xbase_dataobj_t<xblockchain2_t, xdata_type_blockchain> {
+class xblockchain2_t : public xbase_dataobj_t<xblockchain2_t, xdata_type_blockchain>
+                     , public common::xenable_execute_block_t<xblockchain2_t> {
  public:
     enum {
         enum_blockchain_ext_type_uncnfirmed_accounts = 1,
@@ -23,15 +26,23 @@ class xblockchain2_t : public xbase_dataobj_t<xblockchain2_t, xdata_type_blockch
     // default is main chain id or get chain id from account
     xblockchain2_t(const std::string & account, base::enum_xvblock_level level);
     xblockchain2_t(const std::string & account);
-    xblockchain2_t();
+    xblockchain2_t() = default;
  protected:
-    virtual ~xblockchain2_t() {}
+     ~xblockchain2_t() override = default;
  private:
     xblockchain2_t(const xblockchain2_t &);
     xblockchain2_t & operator = (const xblockchain2_t &);
  public:
     virtual int32_t do_write(base::xstream_t & stream) override;
     virtual int32_t do_read(base::xstream_t & stream) override;
+
+    void execute_block(xobject_ptr_t<data::xblock_t const> block, std::error_code & ec) override;
+
+private:
+    void execute_genesis_block(xobject_ptr_t<xblock_t const> const & block, std::error_code & ec);
+    void execute_light_block(xobject_ptr_t<xblock_t const> const & block, std::error_code & ec);
+    void execute_full_block(xobject_ptr_t<xblock_t const> const & block, std::error_code & ec);
+    void execute_nil_block(xobject_ptr_t<xblock_t const> const & block, std::error_code & ec);
 
  public:  // update blockchain by block
     bool        update_last_block_state(const xblock_t* block);

--- a/src/xtopcom/xdata/xerror/xerror.h
+++ b/src/xtopcom/xdata/xerror/xerror.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "xbase/xns_macro.h"
+
+#include <cstdint>
+#include <system_error>
+
+NS_BEG3(top, data, error)
+
+enum class xenum_errc {
+    ok,
+    update_state_failed,
+    update_state_block_height_mismatch,
+    update_state_block_type_mismatch,
+};
+using xerrc_t = xenum_errc;
+
+std::error_code make_error_code(xerrc_t const errc) noexcept;
+std::error_condition make_error_condition(xerrc_t const errc) noexcept;
+
+std::error_category const & data_category();
+
+NS_END3
+
+NS_BEG1(std)
+
+template <>
+struct is_error_code_enum<top::data::error::xerrc_t> : std::true_type {
+};
+
+template <>
+struct is_error_condition_enum<top::data::error::xerrc_t> : std::true_type {
+};
+
+NS_END1

--- a/src/xtopcom/xstore/src/xstore.cpp
+++ b/src/xtopcom/xstore/src/xstore.cpp
@@ -348,7 +348,7 @@ data::xblock_t *xstore::get_block_by_height(const std::string &owner, uint64_t h
     return block;
 }
 
-bool xstore::update_blockchain_by_block(xblockchain2_t *blockchain, const data::xblock_t *block, uint64_t now) {
+bool xstore::update_blockchain_by_block(xblockchain2_t *blockchain, const data::xblock_t *block, uint64_t now) const {
 
     blockchain->update_min_max_height(block->get_height());
     blockchain->set_update_stamp(now);
@@ -1310,12 +1310,26 @@ bool  xstore::execute_block(base::xvblock_t* vblock) {
         return false;
     }
 
+#if 0
+    {
+        std::error_code ec;
+        xobject_ptr_t<xblock_t> blk;
+        block->add_ref();
+        blk.attach(block);
+        account->execute_block(std::move(blk), ec);
+        if (ec) {
+            xerror("xstore::execute_block fail-for update blockchain=%s", block->dump().c_str());
+            return false;
+        }
+    }
+#else
     bool bret;
     bret = update_blockchain_by_block(account, block, base::xtime_utl::gettimeofday());
     if (!bret) {
         xerror("xstore::execute_block fail-for update blockchain=%s", block->dump().c_str());
         return false;
     }
+#endif
 
     xstore_key_t blockchain_key(xstore_key_t(xstore_key_type_blockchain, xstore_block_type_none, account->get_account(), {}));
     auto blockchain_pair = generate_db_object(blockchain_key, account);

--- a/src/xtopcom/xstore/xstore.h
+++ b/src/xtopcom/xstore/xstore.h
@@ -157,7 +157,7 @@ public:
     xdataobj_ptr_t get_property(const std::string & account, const std::string & prop_name, int32_t type);
     bool set_transaction_hash(xstore_transaction_t& txn, const uint64_t unit_height, const std::string &txhash, enum_transaction_subtype txtype, xtransaction_t* tx);
 
-    bool update_blockchain_by_block(xblockchain2_t* blockchain, const data::xblock_t* block, uint64_t now);
+    bool update_blockchain_by_block(xblockchain2_t* blockchain, const data::xblock_t* block, uint64_t now) const;
 
     bool save_block(const std::string & store_path, data::xblock_t* block);
 

--- a/src/xtopcom/xvledger/xdataobj_base.hpp
+++ b/src/xtopcom/xvledger/xdataobj_base.hpp
@@ -57,7 +57,7 @@ enum enum_xtopcom_object_type {
 };
 
 
-template <typename T, int type_value>
+template <typename T, enum_xtopcom_object_type type_value>
 class xbase_dataobj_t : public base::xdataobj_t {
  protected:
     enum { object_type_value = enum_xdata_type_max - type_value };

--- a/tests/xbasic/src/test_serializable_based_on.cpp
+++ b/tests/xbasic/src/test_serializable_based_on.cpp
@@ -97,6 +97,17 @@ TEST(serializable, read_old_data1) {
     EXPECT_EQ(expected.i, actual.i);
     EXPECT_EQ(expected.j, actual.j);
     EXPECT_EQ(expected.next, actual.next);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    old_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_EQ(expected.next, actual2.next);
 }
 
 TEST(serializable, read_old_data2) {
@@ -118,6 +129,19 @@ TEST(serializable, read_old_data2) {
     EXPECT_TRUE(actual.next != nullptr);
     EXPECT_EQ(expected.next->i, actual.next->i);
     EXPECT_EQ(expected.next->j, actual.next->j);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    old_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next != nullptr);
+    EXPECT_EQ(expected.next->i, actual2.next->i);
+    EXPECT_EQ(expected.next->j, actual2.next->j);
 }
 
 TEST(serializable, new_read_old_data1) {
@@ -140,6 +164,20 @@ TEST(serializable, new_read_old_data1) {
     EXPECT_TRUE(actual.pre == nullptr);
     EXPECT_EQ(expected.next->i, actual.next->i);
     EXPECT_EQ(expected.next->j, actual.next->j);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    new_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next != nullptr);
+    EXPECT_TRUE(actual2.pre == nullptr);
+    EXPECT_EQ(expected.next->i, actual2.next->i);
+    EXPECT_EQ(expected.next->j, actual2.next->j);
 }
 
 TEST(serializable, new_read_old_data2) {
@@ -157,6 +195,18 @@ TEST(serializable, new_read_old_data2) {
     EXPECT_EQ(expected.j, actual.j);
     EXPECT_TRUE(actual.next == nullptr);
     EXPECT_TRUE(actual.pre == nullptr);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    new_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next == nullptr);
+    EXPECT_TRUE(actual2.pre == nullptr);
 }
 
 TEST(serializable, old_read_new_data1) {
@@ -173,6 +223,17 @@ TEST(serializable, old_read_new_data1) {
     EXPECT_EQ(expected.i, actual.i);
     EXPECT_EQ(expected.j, actual.j);
     EXPECT_TRUE(actual.next == nullptr);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    old_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next == nullptr);
 }
 
 TEST(serializable, old_read_new_data2) {
@@ -200,6 +261,22 @@ TEST(serializable, old_read_new_data2) {
     EXPECT_TRUE(expected.next->next != nullptr);
     EXPECT_EQ(expected.next->next->i, actual.next->next->i);
     EXPECT_EQ(expected.next->next->j, actual.next->next->j);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    old_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next != nullptr);
+    EXPECT_EQ(expected.next->i, actual2.next->i);
+    EXPECT_EQ(expected.next->j, actual2.next->j);
+    EXPECT_TRUE(expected.next->next != nullptr);
+    EXPECT_EQ(expected.next->next->i, actual2.next->next->i);
+    EXPECT_EQ(expected.next->next->j, actual2.next->next->j);
 }
 
 TEST(serializable, old_read_new_data3) {
@@ -230,4 +307,31 @@ TEST(serializable, old_read_new_data3) {
     EXPECT_TRUE(expected.next->next != nullptr);
     EXPECT_EQ(expected.next->next->i, actual.next->next->i);
     EXPECT_EQ(expected.next->next->j, actual.next->next->j);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    old_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next != nullptr);
+    EXPECT_EQ(expected.next->i, actual2.next->i);
+    EXPECT_EQ(expected.next->j, actual2.next->j);
+    EXPECT_TRUE(expected.next->next != nullptr);
+    EXPECT_EQ(expected.next->next->i, actual2.next->next->i);
+    EXPECT_EQ(expected.next->next->j, actual2.next->next->j);
+}
+
+TEST(serializable, deserialize_from_invalid_input) {
+    std::error_code ec;
+    top::xbyte_buffer_t empty_bytes;
+
+    EXPECT_NO_THROW(
+        old_data data;
+        data.deserialize_based_on<top::base::xstream_t>(empty_bytes, ec);
+    );
+    EXPECT_NE(0, ec.value());
 }

--- a/tests/xblockstore2_test/CMakeLists.txt
+++ b/tests/xblockstore2_test/CMakeLists.txt
@@ -10,6 +10,8 @@ add_dependencies(xblockstore2_test xblockstore)
 include_directories(src/xtopcom/xblockstore/)
 target_link_libraries(xblockstore2_test PRIVATE
     xblockstore
+    xdata
+    xcommon
     gtest
 )
 


### PR DESCRIPTION
1. enable xblockchain2_t's execute_block functionality.
2. enrich xserializable_base_on<T> & corresponding tests.