### PR TITLE
feat(xdata): move unit block state update into blockchain2

### DIFF
--- a/src/xtopcom/xbasic/src/xchain_error.cpp
+++ b/src/xtopcom/xbasic/src/xchain_error.cpp
@@ -7,31 +7,31 @@
 
 NS_BEG2(top, error)
 
-xtop_chain_error::xtop_chain_error(std::error_code ec)
+xtop_top_error::xtop_top_error(std::error_code ec)
     : base_t{ ec.message() }, m_ec{ std::move(ec) } {
 }
 
-xtop_chain_error::xtop_chain_error(std::error_code ec, char const * extra_what)
+xtop_top_error::xtop_top_error(std::error_code ec, char const * extra_what)
     : base_t{ ec.message() + ": " + extra_what }, m_ec{ std::move(ec) } {
 }
 
-xtop_chain_error::xtop_chain_error(std::error_code ec, std::string const & extra_what)
+xtop_top_error::xtop_top_error(std::error_code ec, std::string const & extra_what)
     : base_t{ ec.message() + ": " + extra_what}, m_ec{ std::move(ec) } {
 }
 
-xtop_chain_error::xtop_chain_error(int const ev, std::error_category const & ecat)
+xtop_top_error::xtop_top_error(int const ev, std::error_category const & ecat)
     : base_t{ std::error_code{ ev, ecat }.message() }, m_ec{ ev, ecat } {
 }
 
-xtop_chain_error::xtop_chain_error(int const ev, std::error_category const & ecat, char const * extra_what)
+xtop_top_error::xtop_top_error(int const ev, std::error_category const & ecat, char const * extra_what)
     : base_t{ std::error_code{ ev, ecat}.message() + ": " + extra_what }, m_ec{ ev, ecat } {
 }
 
-xtop_chain_error::xtop_chain_error(int const ev, std::error_category const & ecat, std::string const & extra_what)
+xtop_top_error::xtop_top_error(int const ev, std::error_category const & ecat, std::string const & extra_what)
     : base_t{ std::error_code{ ev, ecat}.message() + ": " + extra_what }, m_ec{ ev, ecat } {
 }
 
-std::error_code const & xtop_chain_error::code() const noexcept {
+std::error_code const & xtop_top_error::code() const noexcept {
     return m_ec;
 }
 

--- a/src/xtopcom/xbasic/src/xerror.cpp
+++ b/src/xtopcom/xbasic/src/xerror.cpp
@@ -46,23 +46,6 @@ std::error_category const & basic_category() {
     return category;
 }
 
-xtop_basic_error::xtop_basic_error(xbasic_errc_t errc) : xtop_basic_error{make_error_code(errc)} {
-}
-
-xtop_basic_error::xtop_basic_error(xbasic_errc_t errc, std::string extra_msg) : xtop_basic_error{make_error_code(errc), std::move(extra_msg)} {
-}
-
-xtop_basic_error::xtop_basic_error(std::error_code ec) : std::runtime_error{ec.message()}, m_ec{std::move(ec)} {
-}
-
-xtop_basic_error::xtop_basic_error(std::error_code ec, std::string extra_msg)
-  : std::runtime_error{extra_msg += ":" + ec.message()}, m_ec{std::move(ec)} {
-}
-
-std::error_code const & xtop_basic_error::code() const noexcept {
-    return m_ec;
-}
-
 NS_END2
 
 NS_BEG1(std)

--- a/src/xtopcom/xbasic/src/xserializable_based_on.cpp
+++ b/src/xtopcom/xbasic/src/xserializable_based_on.cpp
@@ -97,7 +97,7 @@ template <>
 xbyte_buffer_t xtop_serializable_based_on<void>::serialize_based_on<base::xstream_t>(std::error_code & ec) const {
     try {
         return serialize_based_on<base::xstream_t>();
-    } catch (top::error::xchain_error_t const & eh) {
+    } catch (top::error::xtop_error_t const & eh) {
         ec = eh.code();
 #if defined(XENABLE_TESTS)
         xwarn("xserializable_based_on serialize error category %s; msg %s", ec.category().name(), eh.what());
@@ -143,7 +143,7 @@ template <>
 void xtop_serializable_based_on<void>::deserialize_based_on<base::xstream_t>(xbyte_buffer_t bytes, std::error_code & ec) {
     try {
         deserialize_based_on<base::xstream_t>(std::move(bytes));
-    } catch (top::error::xchain_error_t const & eh) {
+    } catch (top::error::xtop_error_t const & eh) {
         ec = eh.code();
 #if defined(XENABLE_TESTS)
         xwarn("xserializable_based_on deserialize error category %s; msg %s", ec.category().name(), eh.what());

--- a/src/xtopcom/xbasic/src/xserializable_based_on.cpp
+++ b/src/xtopcom/xbasic/src/xserializable_based_on.cpp
@@ -2,9 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "xbase/xcontext.h"
 #include "xbasic/xserializable_based_on.h"
+
+#include "xbase/xcontext.h"
+#include "xbase/xlog.h"
+#include "xbasic/xerror/xchain_error.h"
 #include "xbasic/xerror/xerror.h"
+#include "xbasic/xerror/xthrow_error.h"
 
 #include <cassert>
 
@@ -76,6 +80,98 @@ std::int32_t xtop_serializable_based_on<void>::serialize_from(base::xbuffer_t & 
         ec = top::error::xbasic_errc_t::deserialization_error;
     }
     return -1;
+}
+
+template <>
+xbyte_buffer_t xtop_serializable_based_on<void>::serialize_based_on<base::xstream_t>() const {
+    base::xstream_t stream{ base::xcontext_t::instance() };
+    if (do_write(stream) <= 0) {
+        std::error_code ec = top::error::xbasic_errc_t::serialization_error;
+        top::error::throw_error(ec);
+    }
+
+    return { stream.data(), stream.data() + static_cast<size_t>(stream.size()) };
+}
+
+template <>
+xbyte_buffer_t xtop_serializable_based_on<void>::serialize_based_on<base::xstream_t>(std::error_code & ec) const {
+    try {
+        return serialize_based_on<base::xstream_t>();
+    } catch (top::error::xchain_error_t const & eh) {
+        ec = eh.code();
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on serialize error category %s; msg %s", ec.category().name(), eh.what());
+#else
+        xerror("xserializable_based_on serialize error category %s; msg %s", ec.category().name(), eh.what());
+#endif
+    } catch (std::exception const & eh) {
+        ec = top::error::xbasic_errc_t::serialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on serialize error %s", eh.what());
+#else
+        xerror("xserializable_based_on serialize error %s", eh.what());
+#endif
+    } catch (enum_xerror_code const error_code) {
+        ec = top::error::xbasic_errc_t::serialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on serialize error code %d", static_cast<int>(error_code));
+#else
+        xerror("xserializable_based_on serialize error code %d", static_cast<int>(error_code));
+#endif
+    } catch (...) {
+        ec = top::error::xbasic_errc_t::serialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("%s", "xserializable_based_on serialize unknown error");
+#else
+        xerror("%s", "xserializable_based_on serialize unknown error");
+#endif
+    }
+
+    return {};
+}
+
+template <>
+void xtop_serializable_based_on<void>::deserialize_based_on<base::xstream_t>(xbyte_buffer_t bytes) {
+    base::xstream_t stream{ base::xcontext_t::instance(), bytes.data(), static_cast<uint32_t>(bytes.size()) };
+    if (do_read(stream) <= 0) {
+        std::error_code ec{ top::error::xbasic_errc_t::deserialization_error };
+        top::error::throw_error(ec);
+    }
+}
+
+template <>
+void xtop_serializable_based_on<void>::deserialize_based_on<base::xstream_t>(xbyte_buffer_t bytes, std::error_code & ec) {
+    try {
+        deserialize_based_on<base::xstream_t>(std::move(bytes));
+    } catch (top::error::xchain_error_t const & eh) {
+        ec = eh.code();
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on deserialize error category %s; msg %s", ec.category().name(), eh.what());
+#else
+        xerror("xserializable_based_on deserialize error category %s; msg %s", ec.category().name(), eh.what());
+#endif
+    } catch (std::exception const & eh) {
+        ec = top::error::xbasic_errc_t::deserialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on deserialize error %s", eh.what());
+#else
+        xerror("xserializable_based_on deserialize error %s", eh.what());
+#endif
+    } catch (enum_xerror_code const error_code) {
+        ec = top::error::xbasic_errc_t::deserialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("xserializable_based_on deserialize error code %d", static_cast<int>(error_code));
+#else
+        xerror("xserializable_based_on deserialize error code %d", static_cast<int>(error_code));
+#endif
+    } catch (...) {
+        ec = top::error::xbasic_errc_t::deserialization_error;
+#if defined(XENABLE_TESTS)
+        xwarn("%s", "xserializable_based_on deserialize unknown error");
+#else
+        xerror("%s", "xserializable_based_on deserialize unknown error");
+#endif
+    }
 }
 
 std::int32_t xtop_serializable_based_on<void>::do_write(base::xstream_t & stream, std::error_code & ec) const {

--- a/src/xtopcom/xbasic/src/xthrow_error.cpp
+++ b/src/xtopcom/xbasic/src/xthrow_error.cpp
@@ -9,17 +9,17 @@
 NS_BEG2(top, error)
 
 void do_throw_error(std::error_code const & ec) {
-    xchain_error_t eh{ ec };
+    xtop_error_t eh{ ec };
     throw_exception(eh);
 }
 
 void do_throw_error(std::error_code const & ec, char const * extra_what) {
-    xchain_error_t eh{ ec, extra_what };
+    xtop_error_t eh{ ec, extra_what };
     throw_exception(eh);
 }
 
 void do_throw_error(std::error_code const & ec, std::string const & extra_what) {
-    xchain_error_t eh{ ec, extra_what };
+    xtop_error_t eh{ ec, extra_what };
     throw_exception(eh);
 }
 

--- a/src/xtopcom/xbasic/xclonable.h
+++ b/src/xtopcom/xbasic/xclonable.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.#pragma once
+
+#pragma once
+
+#include "xbase/xobject_ptr.h"
+#include "xbase/xrefcount.h"
+
+#include <type_traits>
+
+NS_BEG1(top)
+
+template <class T, class U>
+class xtop_clonable {
+public:
+    xtop_clonable() = default;
+    xtop_clonable(xtop_clonable const &) = delete;
+    xtop_clonable & operator=(xtop_clonable const &) = delete;
+    xtop_clonable(xtop_clonable &&) = default;
+    xtop_clonable & operator=(xtop_clonable &&) = default;
+    virtual ~xtop_clonable() = default;
+
+    virtual U clone() const = 0;
+};
+
+template <class T, template <class> class SmartPtrT>
+class xtop_clonable<T, SmartPtrT<T>> {
+public:
+    xtop_clonable() = default;
+    xtop_clonable(xtop_clonable const &) = delete;
+    xtop_clonable & operator=(xtop_clonable const &) = delete;
+    xtop_clonable(xtop_clonable &&) = default;
+    xtop_clonable & operator=(xtop_clonable &&) = default;
+    virtual ~xtop_clonable() = default;
+
+    virtual SmartPtrT<T> clone() const = 0;
+};
+
+//template <typename T, typename std::enable_if<!std::is_base_of<base::xrefcount_t, T>::value>::type * = nullptr>
+//class xtop_clonable {
+//public:
+//    xtop_clonable() = default;
+//    xtop_clonable(xtop_clonable const &) = delete;
+//    xtop_clonable & operator=(xtop_clonable const &) = delete;
+//    xtop_clonable(xtop_clonable &&) = default;
+//    xtop_clonable & operator=(xtop_clonable &&) = default;
+//    virtual ~xtop_clonable() = default;
+//
+//    virtual T clone() const = 0;
+//};
+
+template <class T, template <class> class SmartPtrT = xobject_ptr_t>
+using xclonable_t = xtop_clonable<T, SmartPtrT<T>>;
+
+NS_END1

--- a/src/xtopcom/xbasic/xenable_to_string.h
+++ b/src/xtopcom/xbasic/xenable_to_string.h
@@ -31,7 +31,7 @@ public:
         assert(!ec);
         try {
             return to_string();
-        } catch (top::error::xbasic_error_t const & eh) {
+        } catch (top::error::xtop_error_t const & eh) {
             ec = eh.code();
             xwarn("%s", (std::string{typeid(T).name()} + "::to_string failed").c_str());
         } catch (...) {
@@ -54,7 +54,7 @@ public:
             if (ret <= 0) {
                 ec = top::error::xbasic_errc_t::deserialization_error;
             }
-        } catch (top::error::xbasic_error_t const & eh) {
+        } catch (top::error::xtop_error_t const & eh) {
             ec = eh.code();
             xwarn("%s", (std::string{typeid(T).name()} + "::from_string failed").c_str());
         } catch (...) {

--- a/src/xtopcom/xbasic/xerror/xchain_error.h
+++ b/src/xtopcom/xbasic/xerror/xchain_error.h
@@ -1,6 +1,8 @@
-// Copyright (c) 2017-2018 Telos Foundation & contributors
+// Copyright (c) 2017-2021 Telos Foundation & contributors
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
 
 #include "xbase/xns_macro.h"
 
@@ -9,29 +11,29 @@
 
 NS_BEG2(top, error)
 
-class xtop_chain_error : public std::runtime_error {
+class xtop_top_error : public std::runtime_error {
     using base_t = std::runtime_error;
 
     std::error_code m_ec{};
 
 public:
-    xtop_chain_error()                                     = default;
-    xtop_chain_error(xtop_chain_error const &)             = default;
-    xtop_chain_error & operator=(xtop_chain_error const &) = default;
-    xtop_chain_error(xtop_chain_error &&)                  = default;
-    xtop_chain_error & operator=(xtop_chain_error &&)      = default;
-    ~xtop_chain_error() override                           = default;
+    xtop_top_error()                                   = default;
+    xtop_top_error(xtop_top_error const &)             = default;
+    xtop_top_error & operator=(xtop_top_error const &) = default;
+    xtop_top_error(xtop_top_error &&)                  = default;
+    xtop_top_error & operator=(xtop_top_error &&)      = default;
+    ~xtop_top_error() override                         = default;
 
-    explicit xtop_chain_error(std::error_code ec);
-    xtop_chain_error(std::error_code ec, std::string const & extra_what);
-    xtop_chain_error(std::error_code ec, char const * extra_what);
-    xtop_chain_error(int const ev, std::error_category const & ecat);
-    xtop_chain_error(int const ev, std::error_category const & ecat, std::string const & extra_what);
-    xtop_chain_error(int const ev, std::error_category const & ecat, char const * extra_what);
+    explicit xtop_top_error(std::error_code ec);
+    xtop_top_error(std::error_code ec, std::string const & extra_what);
+    xtop_top_error(std::error_code ec, char const * extra_what);
+    xtop_top_error(int const ev, std::error_category const & ecat);
+    xtop_top_error(int const ev, std::error_category const & ecat, std::string const & extra_what);
+    xtop_top_error(int const ev, std::error_category const & ecat, char const * extra_what);
 
     std::error_code const &
     code() const noexcept;
 };
-using xchain_error_t = xtop_chain_error;
+using xtop_error_t = xtop_top_error;
 
 NS_END2

--- a/src/xtopcom/xbasic/xerror/xerror.h
+++ b/src/xtopcom/xbasic/xerror/xerror.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "xbase/xns_macro.h"
+#include "xbasic/xerror/xchain_error.h"
 
 #include <limits>
 #include <system_error>
@@ -22,22 +22,6 @@ std::error_condition make_error_condition(xbasic_errc_t errc) noexcept;
 
 std::error_category const & basic_category();
 
-class xtop_basic_error : public std::runtime_error {
-public:
-    xtop_basic_error(xbasic_errc_t const error_code);
-    xtop_basic_error(xbasic_errc_t const error_code, std::string extra_msg);
-
-    std::error_code const & code() const noexcept;
-
-private:
-    xtop_basic_error(std::error_code ec);
-    xtop_basic_error(std::error_code ec, std::string extra_msg);
-
-private:
-    std::error_code m_ec;
-};
-using xbasic_error_t = xtop_basic_error;
-
 NS_END2
 
 NS_BEG1(std)
@@ -49,12 +33,13 @@ struct hash<top::error::xbasic_errc_t> final {
     size_t operator()(top::error::xbasic_errc_t errc) const noexcept;
 };
 
+#endif
+
 template <>
 struct is_error_code_enum<top::error::xbasic_errc_t> : std::true_type {};
 
 template <>
 struct is_error_condition_enum<top::error::xbasic_errc_t> : std::true_type {};
 
-#endif
 
 NS_END1

--- a/src/xtopcom/xbasic/xerror/xthrow_error.h
+++ b/src/xtopcom/xbasic/xerror/xthrow_error.h
@@ -1,8 +1,8 @@
-// Copyright (c) 2017-2018 Telos Foundation & contributors
+// Copyright (c) 2017-2021 Telos Foundation & contributors
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "xbase/xns_macro.h"
+#include "xbasic/xerror/xchain_error.h"
 
 #include <string>
 #include <system_error>

--- a/src/xtopcom/xbasic/xserializable_based_on.h
+++ b/src/xtopcom/xbasic/xserializable_based_on.h
@@ -27,6 +27,7 @@
 #endif
 
 #include "xbase/xns_macro.h"
+#include "xbasic/xbyte_buffer.h"
 
 #include <cstdint>
 #include <string>
@@ -103,6 +104,18 @@ public:
 
     std::int32_t serialize_from(base::xbuffer_t & stream, std::error_code & ec);
 
+    template <typename StreamT>
+    xbyte_buffer_t serialize_based_on() const;
+
+    template <typename StreamT>
+    xbyte_buffer_t serialize_based_on(std::error_code & ec) const;
+
+    template <typename StreamT>
+    void deserialize_based_on(xbyte_buffer_t bytes);
+
+    template <typename StreamT>
+    void deserialize_based_on(xbyte_buffer_t bytes, std::error_code & ec);
+
 protected:
     /**
      * @brief Serialize the object into the steam directly.
@@ -124,3 +137,18 @@ using xserializable_based_on = xtop_serializable_based_on<BasedOnT>;
 
 NS_END1
 
+NS_BEG1(top)
+
+template <>
+xbyte_buffer_t xtop_serializable_based_on<void>::serialize_based_on<base::xstream_t>() const;
+
+template <>
+xbyte_buffer_t xtop_serializable_based_on<void>::serialize_based_on<base::xstream_t>(std::error_code & ec) const;
+
+template <>
+void xtop_serializable_based_on<void>::deserialize_based_on<base::xstream_t>(xbyte_buffer_t bytes);
+
+template <>
+void xtop_serializable_based_on<void>::deserialize_based_on<base::xstream_t>(xbyte_buffer_t bytes, std::error_code & ec);
+
+NS_END1

--- a/src/xtopcom/xchain_upgrade/src/xchain_upgrade_center.cpp
+++ b/src/xtopcom/xchain_upgrade/src/xchain_upgrade_center.cpp
@@ -17,7 +17,7 @@ namespace top {
             xfork_point_t{xfork_point_type_t::logic_time, 3904920, "reward contract save reward detail"},
             xfork_point_t{xfork_point_type_t::logic_time, 3913560, "vote contract trx split fork point"},
             xfork_point_t{xfork_point_type_t::logic_time, 4000000, "rec standby update programe version"},
-            xfork_point_t{xfork_point_type_t::logic_time, 5000000, "slash and workload contract upgrade"}
+            xfork_point_t{xfork_point_type_t::logic_time, common::xjudgement_day, "slash and workload contract upgrade"}
         };
 
         // !!!change!!! fork time for galileo
@@ -27,7 +27,7 @@ namespace top {
             xfork_point_t{xfork_point_type_t::logic_time, 3904920, "reward contract save reward detail"},
             xfork_point_t{xfork_point_type_t::logic_time, 3913560, "vote contract trx split fork point"},
             xfork_point_t{xfork_point_type_t::logic_time, 4000000, "rec standby update programe version"},
-            xfork_point_t{xfork_point_type_t::logic_time, 5000000, "slash and workload contract upgrade"}
+            xfork_point_t{xfork_point_type_t::logic_time, common::xjudgement_day, "slash and workload contract upgrade"}
         };
 
         // !!!change!!! fork time for local develop net
@@ -37,7 +37,7 @@ namespace top {
             xfork_point_t{xfork_point_type_t::logic_time, 3904920, "reward contract save reward detail"},
             xfork_point_t{xfork_point_type_t::logic_time, 3913560, "vote contract trx split fork point"},
             xfork_point_t{xfork_point_type_t::logic_time, 4000000, "rec standby update programe version"},
-            xfork_point_t{xfork_point_type_t::logic_time, 5000000, "slash and workload contract upgrade"}
+            xfork_point_t{xfork_point_type_t::logic_time, common::xjudgement_day, "slash and workload contract upgrade"}
         };
 
         xchain_fork_config_t const & xtop_chain_fork_config_center::chain_fork_config() noexcept {

--- a/src/xtopcom/xcommon/xaddress_error.h
+++ b/src/xtopcom/xcommon/xaddress_error.h
@@ -67,9 +67,9 @@ make_error_condition(xaddress_errc_t const errc);
 std::error_category const &
 address_category();
 
-class xtop_address_error final : public top::error::xchain_error_t
+class xtop_address_error final : public top::error::xtop_error_t
 {
-    using base_t = top::error::xchain_error_t;
+    using base_t = top::error::xtop_error_t;
 
 public:
     xtop_address_error(xaddress_errc_t const errc, std::size_t const line, char const * file);

--- a/src/xtopcom/xcommon/xenable_execute_block.h
+++ b/src/xtopcom/xcommon/xenable_execute_block.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.#pragma once
+
+#pragma once
+
+#include "xbase/xobject_ptr.h"
+#include "xbasic/xerror/xthrow_error.h"
+#include "xdata/xblock.h"
+
+#include <system_error>
+
+NS_BEG2(top, common)
+
+template <class T, template <typename> class SmartPtrT>
+class xtop_enable_execute_block {
+public:
+    xtop_enable_execute_block() = default;
+    xtop_enable_execute_block(xtop_enable_execute_block const &) = delete;
+    xtop_enable_execute_block & operator=(xtop_enable_execute_block const &) = delete;
+    xtop_enable_execute_block(xtop_enable_execute_block &&) = default;
+    xtop_enable_execute_block & operator=(xtop_enable_execute_block &&) = default;
+    virtual ~xtop_enable_execute_block() = default;
+
+    /// @brief Apply block data onto current object of type T.
+    /// @param block The block object to be applied.
+    /// @param ec The error code that will be set in the execute process.
+    virtual void execute_block(SmartPtrT<data::xblock_t const> block, std::error_code & ec) = 0;
+
+    /// @brief Apply block data onto current object of type T.
+    ///        If any error is seen, top::error::xchain_error_t exception will be thrown.
+    /// @param block The block object ot be applied.
+    virtual void execute_block(SmartPtrT<data::xblock_t const> block) {
+        std::error_code ec;
+        execute_block(std::move(block), ec);
+        top::error::throw_error(ec);
+    }
+};
+
+template <class T, template <typename> class SmartPtrT = xobject_ptr_t>
+using xenable_execute_block_t = xtop_enable_execute_block<T, SmartPtrT>;
+
+NS_END2

--- a/src/xtopcom/xcommon/xenable_execute_block.h
+++ b/src/xtopcom/xcommon/xenable_execute_block.h
@@ -12,7 +12,7 @@
 
 NS_BEG2(top, common)
 
-template <class T, template <typename> class SmartPtrT>
+template <class StateT, template <typename> class SmartPtrT>
 class xtop_enable_execute_block {
 public:
     xtop_enable_execute_block() = default;
@@ -22,12 +22,18 @@ public:
     xtop_enable_execute_block & operator=(xtop_enable_execute_block &&) = default;
     virtual ~xtop_enable_execute_block() = default;
 
-    /// @brief Apply block data onto current object of type T.
+    /// @brief Apply block data onto current object of type StateT.
     /// @param block The block object to be applied.
     /// @param ec The error code that will be set in the execute process.
     virtual void execute_block(SmartPtrT<data::xblock_t const> block, std::error_code & ec) = 0;
 
-    /// @brief Apply block data onto current object of type T.
+    virtual SmartPtrT<StateT> execute_block(SmartPtrT<data::xblock_t const> block, std::error_code & ec) const {
+        SmartPtrT<StateT> new_state_object = static_cast<StateT const *>(this)->clone();
+        new_state_object->execute_block(std::move(block), ec);
+        return new_state_object;
+    }
+
+    /// @brief Apply block data onto current object of type StateT.
     ///        If any error is seen, top::error::xchain_error_t exception will be thrown.
     /// @param block The block object ot be applied.
     virtual void execute_block(SmartPtrT<data::xblock_t const> block) {

--- a/src/xtopcom/xcommon/xenable_execute_block.h
+++ b/src/xtopcom/xcommon/xenable_execute_block.h
@@ -34,7 +34,7 @@ public:
     }
 
     /// @brief Apply block data onto current object of type StateT.
-    ///        If any error is seen, top::error::xchain_error_t exception will be thrown.
+    ///        If any error is seen, top::error::xtop_error_t exception will be thrown.
     /// @param block The block object ot be applied.
     virtual void execute_block(SmartPtrT<data::xblock_t const> block) {
         std::error_code ec;

--- a/src/xtopcom/xconfig/xpredefined_configurations.h
+++ b/src/xtopcom/xconfig/xpredefined_configurations.h
@@ -138,7 +138,6 @@ XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(max_vote_nodes_num, std::uint32_t, normal,
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(votes_report_interval, xinterval_t, normal, 10, 1, std::numeric_limits<xinterval_t>::max());
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(reward_issue_interval, xinterval_t, normal, 30, 1, std::numeric_limits<xinterval_t>::max());    // 10 minutes
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(workload_timer_interval, xinterval_t, normal, 20, 1, std::numeric_limits<xinterval_t>::max());  // 200 seconds
-XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(workload_collection_interval, xinterval_t, normal, 17, 1, std::numeric_limits<xinterval_t>::max());  // 180 seconds
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(min_node_reward, uint64_t, important, 100, 0, std::numeric_limits<uint64_t>::max());
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(min_voter_dividend, uint64_t, important, 100, 0, std::numeric_limits<uint64_t>::max());
 #else
@@ -151,11 +150,11 @@ XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(max_vote_nodes_num, std::uint32_t, normal,
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(votes_report_interval, xinterval_t, normal, 30, 1, std::numeric_limits<xinterval_t>::max());
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(reward_issue_interval, xinterval_t, normal, 8640, 1, std::numeric_limits<xinterval_t>::max());  // 24 hours
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(workload_timer_interval, xinterval_t, normal, 17, 1, std::numeric_limits<xinterval_t>::max());  // 180 seconds
-XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(workload_collection_interval, xinterval_t, normal, 17, 1, std::numeric_limits<xinterval_t>::max());  // 180 seconds
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(min_node_reward, uint64_t, important, 0, 0, std::numeric_limits<uint64_t>::max());
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(min_voter_dividend, uint64_t, important, 0, 0, std::numeric_limits<uint64_t>::max());
 #endif
 XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(tableworkload_report_schedule_interval, xinterval_t, important, 1, 1, std::numeric_limits<xinterval_t>::max());
+XDECLARE_ONCHAIN_GOVERNANCE_PARAMETER(workload_collection_interval, xinterval_t, normal, 18, 1, std::numeric_limits<xinterval_t>::max());
 // mainnet node active
 
 #if defined XBUILD_GALILEO

--- a/src/xtopcom/xcontract_runtime/CMakeLists.txt
+++ b/src/xtopcom/xcontract_runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_compile_options(-Wall -Werror -Wpedantic)
+add_compile_options(-Wpedantic)
 
 aux_source_directory(./src src_dir)
 add_library(xcontract_runtime STATIC ${src_dir})

--- a/src/xtopcom/xcontract_runtime/src/xaccount_vm.cpp
+++ b/src/xtopcom/xcontract_runtime/src/xaccount_vm.cpp
@@ -103,7 +103,7 @@ xaccount_vm_execution_result_t xtop_account_vm::execute(std::vector<data::xcons_
                 break;
             }
         }
-    } catch (top::error::xchain_error_t & eh) {
+    } catch (top::error::xtop_error_t & eh) {
         xerror("account_vm: caught chain error exception: category: %s msg: %s", eh.code().category().name(), eh.what());
     } catch (std::exception const & eh) {
         xerror("account_vm: caught exception: %s", eh.what());

--- a/src/xtopcom/xcontract_runtime/src/xlua_engine.cpp
+++ b/src/xtopcom/xcontract_runtime/src/xlua_engine.cpp
@@ -186,7 +186,7 @@ int32_t xlua_engine::arg_parse(xbyte_buffer_t const & action_param) {
                 }
             }
         }
-    } catch (top::error::xchain_error_t & e) {
+    } catch (top::error::xtop_error_t & e) {
         throw;
     } catch (const std::exception & e) {
         xkinfo_lua("%s", e.what());
@@ -226,7 +226,7 @@ void xlua_engine::process(observer_ptr<contract_common::xcontract_execution_cont
         } else {
             // TODO: if luapcall is called with third arg non-zero, retrive the return value here
         }
-    } catch (top::error::xchain_error_t const &) {
+    } catch (top::error::xtop_error_t const &) {
         throw;
     } catch (const std::exception & e) {
         xkinfo_lua("%s", e.what());

--- a/src/xtopcom/xcontract_runtime/src/xuser_action_runtime.cpp
+++ b/src/xtopcom/xcontract_runtime/src/xuser_action_runtime.cpp
@@ -21,7 +21,7 @@ xtransaction_execution_result_t xtop_action_runtime<xuser_consensus_action_t>::e
     xtransaction_execution_result_t result;
 
     try {
-    } catch (top::error::xchain_error_t const & eh) {
+    } catch (top::error::xtop_error_t const & eh) {
         result.status.ec = eh.code();
     } catch (std::exception const & eh) {
         result.status.ec = error::xerrc_t::unknown_error;

--- a/src/xtopcom/xcontract_runtime/src/xuser_contract_runtime.cpp
+++ b/src/xtopcom/xcontract_runtime/src/xuser_contract_runtime.cpp
@@ -71,7 +71,7 @@ xtransaction_execution_result_t xtop_user_contract_runtime::execute_transaction(
             engin->load_script(src_code, exe_ctx);
             engin->process(exe_ctx);
         }
-    } catch (top::error::xchain_error_t const & eh) {
+    } catch (top::error::xtop_error_t const & eh) {
         result.status.ec = eh.code();
     } catch (std::exception const & eh) {
         result.status.ec = error::xerrc_t::unknown_error;

--- a/src/xtopcom/xdata/src/xaccount_cmd.cpp
+++ b/src/xtopcom/xdata/src/xaccount_cmd.cpp
@@ -308,7 +308,7 @@ std::map<std::string, xdataobj_ptr_t> xaccount_cmd::get_change_property() {
     return obj_map;
 }
 
-std::map<std::string, xdataobj_ptr_t> xaccount_cmd::get_all_property() {
+std::map<std::string, xdataobj_ptr_t> const & xaccount_cmd::get_all_property() const noexcept {
     return m_clone_objs;
 }
 

--- a/src/xtopcom/xdata/src/xblockchain.cpp
+++ b/src/xtopcom/xdata/src/xblockchain.cpp
@@ -46,8 +46,6 @@ xblockchain2_t::xblockchain2_t(const std::string & account) : m_account(account)
     add_modified_count();
 }
 
-xblockchain2_t::xblockchain2_t() {}
-
 int32_t xblockchain2_t::do_write(base::xstream_t & stream) {
     KEEP_SIZE();
     SERIALIZE_FIELD_BT(m_version);
@@ -417,9 +415,6 @@ void xblockchain2_t::execute_block(xobject_ptr_t<data::xblock_t const> block, st
 
     assert(block->check_block_flag(base::enum_xvblock_flag_committed));
     assert(block->check_block_flag(base::enum_xvblock_flag_locked));
-
-    update_min_max_height(block->get_height());
-    set_update_stamp(base::xtime_utl::gettimeofday());
 
     if (block->is_genesis_block()) {
         xdbg("try to update state by genesis block: block=%s,last_height:%" PRIu64 " max_height:%" PRIu64, block->dump().c_str(), get_last_height(), get_chain_height());

--- a/src/xtopcom/xdata/src/xblockchain.cpp
+++ b/src/xtopcom/xdata/src/xblockchain.cpp
@@ -7,6 +7,8 @@
 #include "xbase/xint.h"
 #include "xbase/xmem.h"
 #include "xbase/xutl.h"
+#include "xbasic/xerror/xerror.h"
+#include "xbasic/xutility.h"
 #include "xbasic/xversion.h"
 #include "xconfig/xconfig_register.h"
 #include "xconfig/xpredefined_configurations.h"
@@ -20,8 +22,10 @@
 #include "xdata/xgenesis_data.h"
 #include "xdata/xlightunit.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cinttypes>
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -94,6 +98,18 @@ int32_t xblockchain2_t::do_read(base::xstream_t & stream) {
     return CALC_LEN();
 }
 
+/////////////////////////// execute block region begin ////////////////////////////////////////
+
+xobject_ptr_t<xblockchain2_t> xblockchain2_t::clone() const {
+    base::xstream_t stream{ base::xcontext_t::instance() };
+    const_cast<xblockchain2_t *>(this)->do_write(stream);
+
+    auto cloned = make_object_ptr<xblockchain2_t>();
+    cloned->do_read(stream);
+
+    return cloned;
+}
+
 void xblockchain2_t::execute_genesis_block(xobject_ptr_t<data::xblock_t const> const & block, std::error_code & ec) {
     assert(!ec);
     assert(!block->get_block_hash().empty());
@@ -122,11 +138,182 @@ void xblockchain2_t::execute_genesis_block(xobject_ptr_t<data::xblock_t const> c
     }
 }
 
-void xblockchain2_t::execute_light_block(xobject_ptr_t<data::xblock_t const> const & block, std::error_code & ec) {
+enum xstore_key_type {
+    xstore_key_type_transaction = 0,
+    xstore_key_type_property = 1,
+    xstore_key_type_property_log = 2,
+    xstore_key_type_block = 3,
+    xstore_key_type_blockchain = 4,
+    xstore_key_type_block_offstate = 5,
+    xstore_key_type_max
+};
+
+enum xstore_block_type {
+    xstore_block_type_none = 0,
+    xstore_block_type_header = 1,
+    xstore_block_type_input = 2,
+    xstore_block_type_output = 3,
+    xstore_block_type_max
+};
+
+class xstore_key_t {
+public:
+    xstore_key_t(int32_t _type, int32_t _block_component, const std::string & _owner, const std::string & _subowner, const std::string & _id)
+        : type(_type), block_component(_block_component), owner(_owner), subowner(_subowner), id(_id) {
+    }
+
+    // xstore_key_t(int32_t _type, int32_t _block_component, const std::string & _owner, const std::string & _subowner, const uint256_t & hash)
+    // : type(_type), block_component(_block_component), owner(_owner), subowner(_subowner), id(std::string((const char*)hash.data(), hash.size())) {}
+
+    xstore_key_t(int32_t _type, int32_t _block_component, const std::string & _owner, const std::string & _subowner)
+        : type(_type), block_component(_block_component), owner(_owner), subowner(_subowner) {
+    }
+
+    std::string to_db_key() const {
+        char buf[KEY_BUFFER_SIZE];
+        memset(buf, 0, sizeof(buf));
+
+        char * begin = buf;
+
+        memcpy(begin, &type, sizeof(type));
+        begin += sizeof(type);
+
+        memcpy(begin, ":", 1);
+        begin += 1;
+
+        memcpy(begin, &block_component, sizeof(block_component));
+        begin += sizeof(block_component);
+
+        memcpy(begin, ":", 1);
+        begin += 1;
+
+        memcpy(begin, owner.c_str(), owner.size());
+        begin += owner.size();
+
+        memcpy(begin, ":", 1);
+        begin += 1;
+
+        memcpy(begin, subowner.c_str(), subowner.size());
+        begin += subowner.size();
+
+        memcpy(begin, ":", 1);
+        begin += 1;
+
+        memcpy(begin, id.c_str(), id.size());
+        begin += id.size();
+
+        return std::string(buf, begin - buf);
+    }
+    std::string printable_key() const {
+        char buf[KEY_BUFFER_SIZE];
+        memset(buf, 0, sizeof(buf));
+
+        int n;
+        if (!id.empty() && is_numeric(id)) {
+            n = snprintf(buf, sizeof(buf), "%d:%d:%s:%s:%s",
+                type, block_component, owner.c_str(), subowner.c_str(), id.c_str());
+        } else {
+            n = snprintf(buf, sizeof(buf), "%d:%d:%s:%s:%s",
+                type, block_component,
+                owner.c_str(), subowner.c_str(),
+                id.empty() ? "" : data::to_hex_str(id).c_str());
+        }
+
+        return std::string(buf, n);
+    }
+
+public:
+    int32_t         type{ 0 };            // data type
+    int32_t         block_component{ 0 };  // block sub type
+    std::string     owner{};           // data owner, eg. acount address
+    std::string     subowner{};        // data name, eg. property's name
+    std::string     id{};              // data id, eg. transaction's hash block's hash
+    static const size_t KEY_BUFFER_SIZE = 512;
+private:
+    bool is_numeric(const std::string & str) const {
+        return std::all_of(std::begin(str), std::end(str), [](int ch) {
+            return isdigit(ch);
+        });
+    }
+};
+
+std::map<std::string, xbyte_buffer_t> xblockchain2_t::execute_light_block(xobject_ptr_t<data::xblock_t const> const & block, std::error_code & ec) {
     assert(!ec);
     assert(!block->get_block_hash().empty());
     assert(block->get_height() >= 1);
     assert(block->get_height() == get_last_height() + 1);
+
+    std::map<std::string, xbyte_buffer_t> updated_properties;
+    auto const * propertylog = block->get_property_log();
+    if (propertylog != nullptr) {
+        auto const & instructions = propertylog->get_instruction();
+        for (auto const & instruction : instructions) {
+            auto const & name = top::get<std::string const>(instruction);
+            auto const & binlogs = top::get<data::xproperty_binlog_t>(instruction).get_logs();
+
+            xdbg("try to execute instruction: name %s", name.c_str());
+
+            for (auto const & binlog : binlogs) {
+                xdbg("try to execute log, op_code %d; op_param1 %s; op_param2 %s",
+                     static_cast<int>(binlog.m_op_code),
+                     binlog.m_op_para1.c_str(),
+                     binlog.m_op_para2.c_str());
+                execute_instruction(name, binlog, ec);
+
+                if (ec) {
+                    return {};
+                }
+            }
+        }
+
+        std::transform(std::begin(m_session_data),
+                       std::end(m_session_data),
+                       std::inserter(updated_properties, std::end(updated_properties)),
+                       [&ec, &block](std::pair<std::string const, xstate_object_t> const & data) {
+            if (ec) {
+                return std::make_pair(std::string{}, xbyte_buffer_t{});
+            }
+
+            auto const & name = top::get<std::string const>(data);
+            auto const & state_object = top::get<xstate_object_t>(data);
+
+            auto const & dataobj = dynamic_xobject_ptr_cast<base::xdataobj_t>(state_object.state_object);
+
+            auto const & actual_prop_hash = xhash_base_t::calc_dataunit_hash(state_object.state_object.get());
+            auto const & expected_prop_hash = block->get_property_hash(name);
+
+            if (actual_prop_hash != expected_prop_hash) {
+                ec = error::xerrc_t::property_hash_mismatch;
+                return std::make_pair(std::string{}, xbyte_buffer_t{});
+            }
+
+            xstore_key_t prop_key{ xstore_key_type_property, xstore_block_type_none, block->get_account(), name };
+            base::xstream_t stream{ base::xcontext_t::instance() };
+            
+            if (dataobj != nullptr) {
+                if (dataobj->full_serialize_to(stream) <= 0) {
+                    xerror("session property data serialization failed");
+                    ec = top::error::xbasic_errc_t::serialization_error;
+                    return std::make_pair(std::string{}, xbyte_buffer_t{});
+                }
+
+                return std::make_pair(prop_key.to_db_key(), xbyte_buffer_t{ stream.data(), stream.data() + stream.size() });
+            } else {
+                std::string serialized_state_object;
+                if (state_object.state_object->serialize_to_string(serialized_state_object) <= 0) {
+                    xerror("session property data serialization failed");
+                    ec = top::error::xbasic_errc_t::serialization_error;
+                    return std::make_pair(std::string{}, xbyte_buffer_t{});
+                }
+
+                return std::make_pair(prop_key.to_db_key(), xbyte_buffer_t{ std::begin(serialized_state_object), std::end(serialized_state_object) });
+            }
+        });
+
+        if (ec) {
+            return {};
+        }
+    }
 
     // the create time of non-genesis account should be set to the gmtime of height#1 block
     if (block->get_height() == 1 && !m_account_state.get_account_create_time()) {
@@ -139,19 +326,58 @@ void xblockchain2_t::execute_light_block(xobject_ptr_t<data::xblock_t const> con
         if (!ret) {
             ec = error::xerrc_t::update_state_failed;
             xwarn("execute light unit failed, add light unit failed");
-            return;
+            return {};
         }
     }
 
     m_last_state_block_height = block->get_height();
     m_last_state_block_hash = block->get_block_hash();
     add_modified_count();
+
+    return updated_properties;
 }
 
 void xblockchain2_t::execute_full_block(xobject_ptr_t<data::xblock_t const> const & block, std::error_code & ec) {
     assert(!ec);
     assert(!block->get_block_hash().empty());
     assert(block->get_block_class() == base::enum_xvblock_class_full);
+
+    std::map<std::string, xbyte_buffer_t> updated_properties;
+    auto const * properties = block->get_fullunit_propertys();
+    if (properties != nullptr) {
+        std::transform(std::begin(*properties),
+                       std::end(*properties),
+                       std::inserter(updated_properties, std::end(updated_properties)),
+                       [&ec, &block](std::pair<std::string, std::string> const & data) {
+            if (ec) {
+                return std::make_pair(std::string{}, xbyte_buffer_t{});
+            }
+
+            auto const & name = data.first;
+            auto const & value = data.second;
+
+            xstore_key_t property_key(xstore_key_type_property, xstore_block_type_none, block->get_account(), name, std::to_string(block->get_height()));
+            return std::make_pair(property_key.to_db_key(), xbyte_buffer_t{ std::begin(value), std::end(value) });
+        });
+
+        bool followed = get_last_height() + 1 == block->get_height();
+        if (followed) {
+            std::transform(std::begin(*properties),
+                std::end(*properties),
+                std::inserter(updated_properties, std::end(updated_properties)),
+                [&ec, &block](std::pair<std::string, std::string> const & data) {
+                if (ec) {
+                    return std::make_pair(std::string{}, xbyte_buffer_t{});
+                }
+
+                auto const & name = data.first;
+                auto const & value = data.second;
+
+                xstore_key_t property_key(xstore_key_type_property, xstore_block_type_none, block->get_account(), name);
+                return std::make_pair(property_key.to_db_key(), xbyte_buffer_t{ std::begin(value), std::end(value) });
+            });
+        }
+    }
 
     if (block->get_block_level() == base::enum_xvblock_level_unit) {
         auto ret = add_full_unit(block.get());
@@ -189,11 +415,12 @@ void xblockchain2_t::execute_block(xobject_ptr_t<data::xblock_t const> block, st
     assert(!ec);
     assert(block != nullptr);
 
+    assert(block->check_block_flag(base::enum_xvblock_flag_committed));
+    assert(block->check_block_flag(base::enum_xvblock_flag_locked));
+
     update_min_max_height(block->get_height());
     set_update_stamp(base::xtime_utl::gettimeofday());
 
-    bool ret{ false };
-    // the local initial block
     if (block->is_genesis_block()) {
         xdbg("try to update state by genesis block: block=%s,last_height:%" PRIu64 " max_height:%" PRIu64, block->dump().c_str(), get_last_height(), get_chain_height());
         execute_genesis_block(block, ec);
@@ -250,6 +477,139 @@ void xblockchain2_t::execute_block(xobject_ptr_t<data::xblock_t const> block, st
         }
     }
 }
+
+void xblockchain2_t::create_property(std::string const & name, xtype_t const type, std::error_code & ec) {
+    assert(type == xtype_t::string || type == xtype_t::map || type == xtype_t::deque);
+
+    auto const it = m_state_data.find(name);
+    if (it != std::end(m_state_data)) {
+        ec = error::xerrc_t::property_already_exist;
+        return;
+    }
+
+    auto string_prop = make_object_ptr<base::xstring_t>();
+    m_state_data.insert({ name, xstate_object_t{ xcategory_t::user, type, string_prop } });
+    m_session_data.insert({ name, xstate_object_t{xcategory_t::user, type, string_prop} });
+}
+
+void xblockchain2_t::delete_property(std::string const & name, std::error_code & ec) {
+    //auto const it = m_state_data.find(name);
+    //if (it != std::end(m_state_data)) {
+    //    if (it->second.state_object != nullptr) {
+    //        
+    //    }
+    //}
+
+    //std::string hash;
+    //auto const has = get_property_hash(name, hash);
+    //if (has) {
+    //    auto obj = 
+    //}
+    //int32_t error_code;
+    //xdataobj_ptr_t obj = get_property(prop_name, error_code);
+    //if (error_code == xaccount_property_has_already_delete || error_code == xaccount_property_not_create) {
+    //    return error_code;
+    //}
+    //m_clone_objs[prop_name] = nullptr;
+    //if (add_flag) {
+    //    m_proplogs->add_instruction(prop_name, xproperty_cmd_type_delete);
+    //}
+}
+
+void xblockchain2_t::execute_instruction(std::string const & property_name, xproperty_instruction_t const & instruction, std::error_code & ec) {
+    assert(!ec);
+
+    switch (instruction.m_op_code) {
+    case xproperty_cmd_type_string_create:
+    {
+        create_property(property_name, xtype_t::string, ec);
+        if (ec) {
+            break;
+        }
+
+        break;
+    }
+
+    case xproperty_cmd_type_list_create:
+    {
+        create_property(property_name,xtype_t::deque, ec);
+        if (ec) {
+            break;
+        }
+
+        break;
+    }
+
+    case xproperty_cmd_type_map_create:
+    {
+        create_property(property_name, xtype_t::map, ec);
+        if (ec) {
+            break;
+        }
+
+        break;
+    }
+
+    case xproperty_cmd_type_delete:
+    {
+        delete_property(property_name, ec);
+        break;
+    }
+
+    case xproperty_cmd_type_string_set:
+    {
+        break;
+    }
+
+    case xproperty_cmd_type_list_push_back:
+    {
+        break;
+    }
+
+    case xproperty_cmd_type_list_push_front:
+    {
+        break;
+    }
+
+    case xproperty_cmd_type_list_pop_back:
+    {
+        break;
+    }
+
+    case xproperty_cmd_type_list_pop_front:
+    {
+        break;
+    }
+
+    case xproperty_cmd_type_list_clear:
+    {
+        break;
+    }
+
+    case xproperty_cmd_type_map_set:
+    {
+        break;
+    }
+
+    case xproperty_cmd_type_map_remove:
+    {
+        break;
+    }
+
+    case xproperty_cmd_type_map_clear:
+    {
+        break;
+    }
+
+    default:
+        assert(false);
+        ec = error::xerrc_t::binlog_instruction_type_invalid;
+        break;
+    }
+}
+
+/////////////////////////// execute block region end //////////////////////////////////////////
+
 
 xtransaction_ptr_t xblockchain2_t::make_transfer_tx(const std::string & to, uint64_t amount, uint64_t firestamp, uint16_t duration, uint32_t deposit, const std::string& token_name) {
     xtransaction_ptr_t tx = make_object_ptr<xtransaction_t>();

--- a/src/xtopcom/xdata/src/xblockchain.cpp
+++ b/src/xtopcom/xdata/src/xblockchain.cpp
@@ -3,22 +3,25 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "xdata/xblockchain.h"
+
 #include "xbase/xint.h"
 #include "xbase/xmem.h"
 #include "xbase/xutl.h"
 #include "xbasic/xversion.h"
 #include "xconfig/xconfig_register.h"
+#include "xconfig/xpredefined_configurations.h"
+#include "xdata/xaccount_cmd.h"
 #include "xdata/xblocktool.h"
 #include "xdata/xdata_common.h"
 #include "xdata/xdata_error.h"
+#include "xdata/xerror/xerror.h"
+#include "xdata/xfull_tableblock.h"
 #include "xdata/xfullunit.h"
 #include "xdata/xgenesis_data.h"
 #include "xdata/xlightunit.h"
-#include "xdata/xfull_tableblock.h"
-#include "xdata/xaccount_cmd.h"
-#include "xconfig/xpredefined_configurations.h"
 
-#include <assert.h>
+#include <cassert>
+#include <cinttypes>
 #include <string>
 #include <vector>
 
@@ -89,6 +92,163 @@ int32_t xblockchain2_t::do_read(base::xstream_t & stream) {
         m_property_objs[prop_name] = prop_obj;
     }
     return CALC_LEN();
+}
+
+void xblockchain2_t::execute_genesis_block(xobject_ptr_t<data::xblock_t const> const & block, std::error_code & ec) {
+    assert(!ec);
+    assert(!block->get_block_hash().empty());
+    assert(block->is_genesis_block());
+
+    // if the genesis block is not the nil block, it must be a "genesis account".
+    // the create time of genesis account should be set to the gmtime of genesis block
+    if (!m_account_state.get_account_create_time() && block->get_header()->get_block_class() != base::enum_xvblock_class_nil) {
+        m_account_state.set_account_create_time(block->get_cert()->get_gmtime());
+        xdbg("execute_genesis_block: address:%s account_create_time:%" PRIu64, block->get_account().c_str(), m_account_state.get_account_create_time());
+    }
+    // update last state
+    if (m_last_state_block_height == 0) {
+        update_last_block_state(block.get());
+        m_last_state_block_height = block->get_height();
+        m_last_state_block_hash = block->get_block_hash();
+        add_modified_count();
+    } else {
+        // disorder set genesis block, only for empty genesis block
+        assert(block->is_emptyblock());
+    }
+    // genesis block as last full block hash
+    if (m_last_full_block_height == 0) {
+        m_last_full_block_height = block->get_height();
+        m_last_full_block_hash = block->get_block_hash();
+    }
+}
+
+void xblockchain2_t::execute_light_block(xobject_ptr_t<data::xblock_t const> const & block, std::error_code & ec) {
+    assert(!ec);
+    assert(!block->get_block_hash().empty());
+    assert(block->get_height() >= 1);
+    assert(block->get_height() == get_last_height() + 1);
+
+    // the create time of non-genesis account should be set to the gmtime of height#1 block
+    if (block->get_height() == 1 && !m_account_state.get_account_create_time()) {
+        m_account_state.set_account_create_time(block->get_cert()->get_gmtime());
+        xdbg("[account change]address:%s account_create_time:%" PRIu64, block->get_account().c_str(), m_account_state.get_account_create_time());
+    }
+
+    if (block->get_block_level() == base::enum_xvblock_level_unit) {
+        auto ret = add_light_unit(block.get());
+        if (!ret) {
+            ec = error::xerrc_t::update_state_failed;
+            xwarn("execute light unit failed, add light unit failed");
+            return;
+        }
+    }
+
+    m_last_state_block_height = block->get_height();
+    m_last_state_block_hash = block->get_block_hash();
+    add_modified_count();
+}
+
+void xblockchain2_t::execute_full_block(xobject_ptr_t<data::xblock_t const> const & block, std::error_code & ec) {
+    assert(!ec);
+    assert(!block->get_block_hash().empty());
+    assert(block->get_block_class() == base::enum_xvblock_class_full);
+
+    if (block->get_block_level() == base::enum_xvblock_level_unit) {
+        auto ret = add_full_unit(block.get());
+        if (!ret) {
+            ec = error::xerrc_t::update_state_failed;
+            xwarn("execute full unit failed, add full unit failed");
+            return;
+        }
+    }
+
+    assert(block->get_height() > m_last_state_block_height);
+    m_last_state_block_height = block->get_height();
+    m_last_state_block_hash = block->get_block_hash();
+    add_modified_count();
+}
+
+void xblockchain2_t::execute_nil_block(xobject_ptr_t<data::xblock_t const> const & block, std::error_code & ec) {
+    assert(!ec);
+    assert(!block->get_block_hash().empty());
+    assert(block->get_height() >= 1);
+    assert(block->get_height() >= get_last_height() + 1);
+
+    // the create time of non-genesis account should be set to the gmtime of height#1 block
+    if (block->get_height() == 1 && !m_account_state.get_account_create_time()) {
+        m_account_state.set_account_create_time(block->get_cert()->get_gmtime());
+        xdbg("[account change]address:%s account_create_time:%" PRIu64, block->get_account().c_str(), m_account_state.get_account_create_time());
+    }
+
+    m_last_state_block_height = block->get_height();
+    m_last_state_block_hash = block->get_block_hash();
+    add_modified_count();
+}
+
+void xblockchain2_t::execute_block(xobject_ptr_t<data::xblock_t const> block, std::error_code & ec) {
+    assert(!ec);
+    assert(block != nullptr);
+
+    update_min_max_height(block->get_height());
+    set_update_stamp(base::xtime_utl::gettimeofday());
+
+    bool ret{ false };
+    // the local initial block
+    if (block->is_genesis_block()) {
+        xdbg("try to update state by genesis block: block=%s,last_height:%" PRIu64 " max_height:%" PRIu64, block->dump().c_str(), get_last_height(), get_chain_height());
+        execute_genesis_block(block, ec);
+        if (ec) {
+            return;
+        }
+    } else {
+        auto const blk_class = block->get_block_class();
+        switch (blk_class) {
+        case base::enum_xvblock_class_light:
+        {
+            // for light block, only the directly followed block can be processed.
+            if (block->get_height() == get_last_height() + 1) {
+                execute_light_block(block, ec);
+            } else {
+                ec = error::xerrc_t::update_state_block_height_mismatch;
+                xdbg("blockchain executes light block but height mismatch. block height %" PRIu64 " state height %" PRIu64, block->get_height(), get_last_height());
+            }
+
+            break;
+        }
+        case base::enum_xvblock_class_full:
+        {
+            // for full block, any block that is followed can be processed.
+            if (block->get_height() >= get_last_height() + 1) {
+                execute_full_block(block, ec);
+            } else {
+                ec = error::xerrc_t::update_state_block_height_mismatch;
+                xdbg("blockchain executes full block but height mismatch. block height %" PRIu64 " state height %" PRIu64, block->get_height(), get_last_height());
+            }
+
+            break;
+        }
+
+        case base::enum_xvblock_class_nil:
+        {
+            // for nil block, any block that is followed can be preocessed.
+            if (block->get_height() >= get_last_height() + 1) {
+                execute_nil_block(block, ec);
+            } else {
+                ec = error::xerrc_t::update_state_block_height_mismatch;
+                xdbg("blockchain executes nil block but height mismatch. block height %" PRIu64 " state height %" PRIu64, block->get_height(), get_last_height());
+            }
+
+            break;
+        }
+
+        default:
+        {
+            ec = error::xerrc_t::update_state_block_type_mismatch;
+            xdbg("blockchain received a block but doesn't know how to execute it. block level %d, block class %d", static_cast<int>(block->get_block_level()), static_cast<int>(block->get_block_class()));
+            break;
+        }
+        }
+    }
 }
 
 xtransaction_ptr_t xblockchain2_t::make_transfer_tx(const std::string & to, uint64_t amount, uint64_t firestamp, uint16_t duration, uint32_t deposit, const std::string& token_name) {

--- a/src/xtopcom/xdata/src/xerror.cpp
+++ b/src/xtopcom/xdata/src/xerror.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2017-2018 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "xdata/xerror/xerror.h"
+
+NS_BEG3(top, data, error)
+
+static char const * const errc_to_string(int code) {
+    auto const ec = static_cast<xerrc_t>(code);
+
+    switch (ec) {
+    case xerrc_t::ok:
+        return "ok";
+
+    case xerrc_t::update_state_failed:
+        return "update state failed";
+
+    case xerrc_t::update_state_block_height_mismatch:
+        return "update state failed due to mismatch block height";
+
+    case xerrc_t::update_state_block_type_mismatch:
+        return "update state failed due to mismatch block type";
+
+    default:
+        return "unknown data module error";
+    }
+}
+
+std::error_code make_error_code(xerrc_t const errc) noexcept {
+    return std::error_code(static_cast<int>(errc), data_category());
+}
+
+std::error_condition make_error_condition(xerrc_t const errc) noexcept {
+    return std::error_condition(static_cast<int>(errc), data_category());
+}
+
+class xtop_data_category final : public std::error_category {
+    char const * name() const noexcept override {
+        return "data";
+    }
+
+    std::string message(int errc) const override {
+        return errc_to_string(errc);
+    }
+};
+using xdata_category_t = xtop_data_category;
+
+std::error_category const & data_category() {
+    static xdata_category_t category{};
+    return category;
+}
+
+NS_END3

--- a/src/xtopcom/xdata/src/xerror.cpp
+++ b/src/xtopcom/xdata/src/xerror.cpp
@@ -22,6 +22,21 @@ static char const * const errc_to_string(int code) {
     case xerrc_t::update_state_block_type_mismatch:
         return "update state failed due to mismatch block type";
 
+    case xerrc_t::property_already_exist:
+        return "property name already exist";
+
+    case xerrc_t::property_type_invalid:
+        return "property type invalid";
+
+    case xerrc_t::property_hash_mismatch:
+        return "property hash mismatch";
+
+    case xerrc_t::property_not_exist:
+        return "property not exist";
+
+    case xerrc_t::binlog_instruction_type_invalid:
+        return "binlog instruction type invalid";
+
     default:
         return "unknown data module error";
     }

--- a/src/xtopcom/xdata/xaccount_cmd.h
+++ b/src/xtopcom/xdata/xaccount_cmd.h
@@ -29,7 +29,7 @@ class xaccount_cmd {
     xaccount_cmd(const std::map<std::string, xdataobj_ptr_t> & property_objs);
     std::map<std::string, std::string> get_property_hash();
     std::map<std::string, xdataobj_ptr_t> get_change_property();
-    std::map<std::string, xdataobj_ptr_t> get_all_property();
+    std::map<std::string, xdataobj_ptr_t> const & get_all_property() const noexcept;
     xproperty_log_ptr_t get_property_log();
 
     int32_t do_property_log(const xproperty_log_ptr_t & logs);

--- a/src/xtopcom/xdata/xblock.h
+++ b/src/xtopcom/xdata/xblock.h
@@ -12,8 +12,6 @@
 #if defined(__clang__)
 
 #    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wall"
-#    pragma clang diagnostic ignored "-Wextra"
 #    pragma clang diagnostic ignored "-Wpedantic"
 
 #elif defined(__GNUC__)

--- a/src/xtopcom/xdata/xblockchain.h
+++ b/src/xtopcom/xdata/xblockchain.h
@@ -5,14 +5,17 @@
 #pragma once
 
 #include <string>
-#include "xdata/xblock.h"
+
 #include "xbase/xobject_ptr.h"
+#include "xcommon/xenable_execute_block.h"
 #include "xdata/xaccount_mstate.h"
+#include "xdata/xblock.h"
 #include "xdata/xtransaction.h"
 
 NS_BEG2(top, data)
 
-class xblockchain2_t : public xbase_dataobj_t<xblockchain2_t, xdata_type_blockchain> {
+class xblockchain2_t : public xbase_dataobj_t<xblockchain2_t, xdata_type_blockchain>
+                     , public common::xenable_execute_block_t<xblockchain2_t> {
  public:
     enum {
         enum_blockchain_ext_type_uncnfirmed_accounts = 1,
@@ -23,15 +26,23 @@ class xblockchain2_t : public xbase_dataobj_t<xblockchain2_t, xdata_type_blockch
     // default is main chain id or get chain id from account
     xblockchain2_t(const std::string & account, base::enum_xvblock_level level);
     xblockchain2_t(const std::string & account);
-    xblockchain2_t();
+    xblockchain2_t() = default;
  protected:
-    virtual ~xblockchain2_t() {}
+     ~xblockchain2_t() override = default;
  private:
     xblockchain2_t(const xblockchain2_t &);
     xblockchain2_t & operator = (const xblockchain2_t &);
  public:
     virtual int32_t do_write(base::xstream_t & stream) override;
     virtual int32_t do_read(base::xstream_t & stream) override;
+
+    void execute_block(xobject_ptr_t<data::xblock_t const> block, std::error_code & ec) override;
+
+private:
+    void execute_genesis_block(xobject_ptr_t<xblock_t const> const & block, std::error_code & ec);
+    void execute_light_block(xobject_ptr_t<xblock_t const> const & block, std::error_code & ec);
+    void execute_full_block(xobject_ptr_t<xblock_t const> const & block, std::error_code & ec);
+    void execute_nil_block(xobject_ptr_t<xblock_t const> const & block, std::error_code & ec);
 
  public:  // update blockchain by block
     bool        update_last_block_state(const xblock_t* block);

--- a/src/xtopcom/xdata/xerror/xerror.h
+++ b/src/xtopcom/xdata/xerror/xerror.h
@@ -16,6 +16,13 @@ enum class xenum_errc {
     update_state_failed,
     update_state_block_height_mismatch,
     update_state_block_type_mismatch,
+
+    property_already_exist,
+    property_type_invalid,
+    property_hash_mismatch,
+    property_not_exist,
+
+    binlog_instruction_type_invalid,
 };
 using xerrc_t = xenum_errc;
 

--- a/src/xtopcom/xdata/xerror/xerror.h
+++ b/src/xtopcom/xdata/xerror/xerror.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "xbase/xns_macro.h"
+
+#include <cstdint>
+#include <system_error>
+
+NS_BEG3(top, data, error)
+
+enum class xenum_errc {
+    ok,
+    update_state_failed,
+    update_state_block_height_mismatch,
+    update_state_block_type_mismatch,
+};
+using xerrc_t = xenum_errc;
+
+std::error_code make_error_code(xerrc_t const errc) noexcept;
+std::error_condition make_error_condition(xerrc_t const errc) noexcept;
+
+std::error_category const & data_category();
+
+NS_END3
+
+NS_BEG1(std)
+
+template <>
+struct is_error_code_enum<top::data::error::xerrc_t> : std::true_type {
+};
+
+template <>
+struct is_error_condition_enum<top::data::error::xerrc_t> : std::true_type {
+};
+
+NS_END1

--- a/src/xtopcom/xdata/xpropertylog.h
+++ b/src/xtopcom/xdata/xpropertylog.h
@@ -170,7 +170,7 @@ class xproperty_binlog_t : public xserializable_based_on<void> {
         return false;
     }
 
-    std::vector<xproperty_instruction_t> get_logs() {
+    std::vector<xproperty_instruction_t> const & get_logs() const noexcept {
         return m_logs;
     }
 

--- a/src/xtopcom/xelection/src/xgroup_element.cpp
+++ b/src/xtopcom/xelection/src/xgroup_element.cpp
@@ -124,7 +124,7 @@ bool xtop_group_element::contains(common::xnode_id_t const & node_id) const noex
     try {
         std::error_code ec;
         return node_element(node_id, ec) != nullptr;
-    } catch (error::xchain_error_t const & eh) {
+    } catch (error::xtop_error_t const & eh) {
         xwarn("xtop_group_element::contains %s", eh.what());
     } catch (std::exception const & eh) {
         xwarn("xtop_group_element::contains %s", eh.what());

--- a/src/xtopcom/xrpc/xgetblock/get_block.cpp
+++ b/src/xtopcom/xrpc/xgetblock/get_block.cpp
@@ -1010,8 +1010,6 @@ void get_block_handle::set_header_info(xJson::Value & header, xblock_t * bp) {
         if (contract::xtop_contract_manager::get_account_from_xip(auditor, addr) == 0) {
             header["auditor"] = addr;
         }
-
-        header["multisign"] = to_hex_str(bp->get_cert()->get_audit_signature());
     }
 
     auto validator = bp->get_cert()->get_validator();
@@ -1021,8 +1019,6 @@ void get_block_handle::set_header_info(xJson::Value & header, xblock_t * bp) {
         if (contract::xtop_contract_manager::get_account_from_xip(validator, addr) == 0) {
             header["validator"] = addr;
         }
-
-        header["multisign"] = to_hex_str(bp->get_cert()->get_verify_signature());
     }
     if (bp->is_tableblock()) {
         header["multisign_auditor"] = to_hex_str(bp->get_cert()->get_audit_signature());

--- a/src/xtopcom/xrpc/xgetblock/get_block.cpp
+++ b/src/xtopcom/xrpc/xgetblock/get_block.cpp
@@ -1010,6 +1010,8 @@ void get_block_handle::set_header_info(xJson::Value & header, xblock_t * bp) {
         if (contract::xtop_contract_manager::get_account_from_xip(auditor, addr) == 0) {
             header["auditor"] = addr;
         }
+
+        header["multisign"] = to_hex_str(bp->get_cert()->get_audit_signature());
     }
 
     auto validator = bp->get_cert()->get_validator();
@@ -1019,6 +1021,8 @@ void get_block_handle::set_header_info(xJson::Value & header, xblock_t * bp) {
         if (contract::xtop_contract_manager::get_account_from_xip(validator, addr) == 0) {
             header["validator"] = addr;
         }
+
+        header["multisign"] = to_hex_str(bp->get_cert()->get_verify_signature());
     }
     if (bp->is_tableblock()) {
         header["multisign_auditor"] = to_hex_str(bp->get_cert()->get_audit_signature());

--- a/src/xtopcom/xstate/CMakeLists.txt
+++ b/src/xtopcom/xstate/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_compile_options(-Wpedantic)
+
+aux_source_directory(./src src_dir)
+add_library(xstate STATIC ${src_dir})
+
+add_dependencies(xstate xdata xcommon xbasic xxbase)
+
+target_link_libraries(xstate PRIVATE xdata xcommon xbasic xxbase pthread)

--- a/src/xtopcom/xstate/src/xerror.cpp
+++ b/src/xtopcom/xstate/src/xerror.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "xstate/xerror/xerror.h"
+
+NS_BEG3(top, state, error)
+
+static char const * errc_to_message(int const errc) noexcept {
+    auto ec = static_cast<error::xerrc_t>(errc);
+    switch (ec) {
+    case xerrc_t::ok:
+        return "successful";
+
+    case xerrc_t::token_insufficient:
+        return "token insufficient";
+
+    default:
+        return "unknown error";
+    }
+}
+
+class xtop_state_category : public std::error_category {
+public:
+    const char * name() const noexcept override {
+        return "state";
+    }
+
+    std::string message(int errc) const override {
+        return errc_to_message(errc);
+    }
+};
+using xstate_category_t = xtop_state_category;
+
+std::error_code make_error_code(xerrc_t errc) noexcept {
+    return std::error_code(static_cast<int>(errc), state_category());
+}
+
+std::error_condition make_error_condition(xerrc_t errc) noexcept {
+    return std::error_condition(static_cast<int>(errc), state_category());
+}
+
+std::error_category const & state_category() {
+    static xstate_category_t category;
+    return category;
+}
+
+NS_END3
+
+NS_BEG1(std)
+
+#if !defined(XCXX14_OR_ABOVE)
+
+size_t hash<top::state::error::xerrc_t>::operator()(top::state::error::xerrc_t errc) const noexcept {
+    return static_cast<size_t>(static_cast<std::underlying_type<top::state::error::xerrc_t>::type>(errc));
+}
+
+#endif
+
+NS_END1

--- a/src/xtopcom/xstate/src/xunit_account.cpp
+++ b/src/xtopcom/xstate/src/xunit_account.cpp
@@ -15,12 +15,12 @@ base::xvaccount_t xtop_unit_account::address() const {
     return base::xvaccount_t{ m_state->get_account_addr() };
 }
 
-uint64_t xtop_unit_account::balance() const {
+uint64_t xtop_unit_account::balance() const noexcept {
     assert(m_state != nullptr);
 
     std::string const balance_property_name{ "balance" };
 
-    auto balance_prop = m_state->load_token_var(balance_property_name);
+    xobject_ptr_t<base::xtokenvar_t> balance_prop = m_state->load_token_var(balance_property_name);
     if (balance_prop == nullptr) {
         balance_prop = m_state->new_token_var(balance_property_name);
     }
@@ -33,7 +33,7 @@ uint64_t xtop_unit_account::nonce() const {
 
     std::string const nonce_property_name{ "nonce" };
 
-    auto nonce_prop = m_state->load_nonce_var(nonce_property_name);
+    xobject_ptr_t<base::xnoncevar_t> nonce_prop = m_state->load_nonce_var(nonce_property_name);
     if (nonce_prop == nullptr) {
         nonce_prop = m_state->new_nonce_var(nonce_property_name);
     }
@@ -45,7 +45,7 @@ uint64_t xtop_unit_account::locked_balance() const {
     return 0;
 }
 
-xobject_ptr_t<base::xdataunit_t> get_property(std::string const & property_name) const {
+xobject_ptr_t<base::xdataunit_t> xtop_unit_account::get_property(std::string const & property_name) const {
     return nullptr;
 }
 

--- a/src/xtopcom/xstate/src/xunit_account.cpp
+++ b/src/xtopcom/xstate/src/xunit_account.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "xstate/xunit_account.h"
+
+#include <cassert>
+
+namespace top {
+namespace state {
+
+base::xvaccount_t xtop_unit_account::address() const {
+    assert(m_state != nullptr);
+
+    return base::xvaccount_t{ m_state->get_account_addr() };
+}
+
+uint64_t xtop_unit_account::balance() const {
+    assert(m_state != nullptr);
+
+    std::string const balance_property_name{ "balance" };
+
+    auto balance_prop = m_state->load_token_var(balance_property_name);
+    if (balance_prop == nullptr) {
+        balance_prop = m_state->new_token_var(balance_property_name);
+    }
+    assert(balance_prop != nullptr);
+    return static_cast<uint64_t>(balance_prop->get_balance());
+}
+
+uint64_t xtop_unit_account::nonce() const {
+    assert(m_state != nullptr);
+
+    std::string const nonce_property_name{ "nonce" };
+
+    auto nonce_prop = m_state->load_nonce_var(nonce_property_name);
+    if (nonce_prop == nullptr) {
+        nonce_prop = m_state->new_nonce_var(nonce_property_name);
+    }
+    assert(nonce_prop != nullptr);
+    return static_cast<uint64_t>(nonce_prop->get_nonce());
+}
+
+uint64_t xtop_unit_account::locked_balance() const {
+    return 0;
+}
+
+xobject_ptr_t<base::xdataunit_t> get_property(std::string const & property_name) const {
+    return nullptr;
+}
+
+}
+}
+
+
+namespace std {
+
+}

--- a/src/xtopcom/xstate/xerror/xerror.h
+++ b/src/xtopcom/xstate/xerror/xerror.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "xbase/xns_macro.h"
+
+#include <cstdint>
+#include <system_error>
+#include <type_traits>
+
+NS_BEG3(top, state, error)
+
+enum class xenum_errc : uint16_t {
+    ok,
+    token_insufficient,
+};
+using xerrc_t = xenum_errc;
+
+std::error_code make_error_code(xerrc_t const ec) noexcept;
+std::error_condition make_error_condition(xerrc_t const ec) noexcept;
+
+std::error_category const & state_category();
+
+NS_END3
+
+NS_BEG1(std)
+
+#if !defined(XCXX14_OR_ABOVE)
+
+template <>
+struct hash<top::state::error::xerrc_t> final {
+    size_t operator()(top::state::error::xerrc_t errc) const noexcept;
+};
+
+#endif
+
+template <>
+struct is_error_code_enum<top::state::error::xerrc_t> : std::true_type {
+};
+
+template <>
+struct is_error_condition_enum<top::state::error::xerrc_t> : std::true_type {
+};
+
+NS_END1

--- a/src/xtopcom/xstate/xstate.h
+++ b/src/xtopcom/xstate/xstate.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "xbase/xns_macro.h"
+
+NS_BEG2(top, state)
+
+class xtop_state {
+
+};
+
+using xstate_t = xtop_state;
+
+NS_END2

--- a/src/xtopcom/xstate/xstate_store_face.h
+++ b/src/xtopcom/xstate/xstate_store_face.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "xbase/xns_macro.h"
+#include "xstore/xstore_face.h"
+
+NS_BEG2(top, state)
+
+class xtop_state_store_face {
+
+};
+
+NS_END2

--- a/src/xtopcom/xstate/xtoken.h
+++ b/src/xtopcom/xstate/xtoken.h
@@ -1,0 +1,94 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "xstate/xerror/xerror.h"
+
+#include <cstdint>
+#include <memory>
+#include <system_error>
+
+NS_BEG2(top, state)
+
+enum class xenum_token_type {
+    invalid,
+    TOP,
+    VPN
+};
+using xtoken_type_t = xenum_token_type;
+
+template <xtoken_type_t TypeV>
+class xtop_token {
+    uint64_t value_{ 0 };
+
+public:
+    xtop_token() = default;
+    xtop_token(xtop_token const &) = delete;
+    xtop_token & operator=(xtop_token const &) = delete;
+    xtop_token(xtop_token && other) noexcept : value_{ other.value_ } {
+        other.value_ = 0;
+    }
+    xtop_token & operator=(xtop_token &&) = delete;
+    ~xtop_token() = default;
+
+protected:
+    xtop_token(uint64_t const amount) noexcept : value_{ amount } {
+    }
+
+public:
+
+    xtop_token withdraw(uint64_t const amount, std::error_code & ec) {
+        if (value_ < amount) {
+            ec = error::xerrc_t::token_insufficient;
+            return;
+        }
+
+        value_ -= amount;
+        return xtop_token{ amount };
+    }
+
+    void depoist(xtop_token & amount, std::error_code & ec) {
+        *this += amount;
+        return *this;
+    }
+
+    bool operator<(xtop_token const & other) const noexcept {
+        return value_ < other.value_;
+    }
+
+    bool operator==(xtop_token const & other) const noexcept {
+        return value_ == other.value_;
+    }
+
+    bool operator>(xtop_token const & other) const noexcept {
+        return other < *this;
+    }
+
+    bool operator!=(xtop_token const & other) const noexcept {
+        return !(*this == other);
+    }
+
+    bool operator<=(xtop_token const & other) const noexcept {
+        return !(*this > other);
+    }
+
+    bool operator>=(xtop_token const & other) const noexcept {
+        return !(*this < other);
+    }
+
+    xtop_token & operator+=(xtop_token & other) noexcept {
+        if (std::addressof(other) == std::addressof(*this)) {
+            return *this;
+        }
+
+        value_ += other.value_;
+        other.value_ = 0;
+    }
+};
+
+template <char const * SYMBOL>
+using xtoken_t = xtop_token;
+
+NS_END2

--- a/src/xtopcom/xstate/xtoken.h
+++ b/src/xtopcom/xstate/xtoken.h
@@ -86,9 +86,27 @@ public:
         value_ += other.value_;
         other.value_ = 0;
     }
+
+    uint64_t data() const noexcept {
+        return value_;
+    }
 };
 
-template <char const * SYMBOL>
-using xtoken_t = xtop_token;
+template <xtoken_type_t TypeV>
+using xtoken_t = xtop_token<TypeV>;
+
+using xtop_token_t = xtoken_t<xtoken_type_t::TOP>;
+using xvpn_token_t = xtoken_t<xtoken_type_t::VPN>;
 
 NS_END2
+
+namespace std {
+
+template <top::state::xtoken_type_t TypeV>
+struct hash<top::state::xtoken_t<TypeV>> {
+    size_t operator()(top::state::xtoken_t<TypeV> const & amount) const noexcept {
+        return static_cast<size_t>(amount.data());
+    }
+};
+
+}

--- a/src/xtopcom/xstate/xunit_account.h
+++ b/src/xtopcom/xstate/xunit_account.h
@@ -19,9 +19,9 @@ class xtop_unit_account : public xunit_state_t {
 
 public:
     base::xvaccount_t address() const override;
-    uint64_t balance() const override;
-    uint64_t nonce() const override;
-    uint64_t locked_balance() const override;
+    uint64_t balance() const noexcept override;
+    uint64_t nonce() const noexcept override;
+    uint64_t locked_balance() const noexcept override;
     xobject_ptr_t<base::xdataunit_t> get_property(std::string const & property_name) const override;
 };
 using xunit_account_t = xtop_unit_account;

--- a/src/xtopcom/xstate/xunit_account.h
+++ b/src/xtopcom/xstate/xunit_account.h
@@ -5,13 +5,25 @@
 #pragma once
 
 #include "xstate/xunit_state.h"
-#include "xvledger/xvaccount.h"
+#include "xvledger/xvstate.h"
 
 NS_BEG2(top, state)
 
 class xtop_unit_account : public xunit_state_t {
+    xobject_ptr_t<base::xvbstate_t> m_state;
+
+    xobject_ptr_t<base::xtokenvar_t> m_balance;
+    xobject_ptr_t<base::xtokenvar_t> m_locked_balance;
+    xobject_ptr_t<base::xnoncevar_t> m_nonce;
+    std::unordered_map<std::string, xobject_ptr_t<base::xvproperty_t>> m_properties;
+
 public:
-    base::xvaccount_t address() const;
+    base::xvaccount_t address() const override;
+    uint64_t balance() const override;
+    uint64_t nonce() const override;
+    uint64_t locked_balance() const override;
+    xobject_ptr_t<base::xdataunit_t> get_property(std::string const & property_name) const override;
 };
+using xunit_account_t = xtop_unit_account;
 
 NS_END2

--- a/src/xtopcom/xstate/xunit_account.h
+++ b/src/xtopcom/xstate/xunit_account.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2018 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "xstate/xunit_state.h"
+#include "xvledger/xvaccount.h"
+
+NS_BEG2(top, state)
+
+class xtop_unit_account : public xunit_state_t {
+public:
+    base::xvaccount_t address() const;
+};
+
+NS_END2

--- a/src/xtopcom/xstate/xunit_state.h
+++ b/src/xtopcom/xstate/xunit_state.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "xstate/xstate.h"
+#include "xstate/xtoken.h"
+#include "xstate/xunit_state_fwd.h"
+#include "xvledger/xvaccount.h"
+
+#include <cstdint>
+
+NS_BEG2(top, state)
+
+using xtoken_t = uint64_t;
+using xnonce_t = uint64_t;
+
+class xtop_unit_state : public xstate_t {
+public:
+    base::xvaccount_t address() const = 0;
+    virtual xtoken_t balance() const noexcept = 0;
+    virtual xnonce_t nonce() const noexcept = 0;
+    virtual xtoken_t locked_balance() const noexcept = 0;
+};
+
+NS_END2

--- a/src/xtopcom/xstate/xunit_state.h
+++ b/src/xtopcom/xstate/xunit_state.h
@@ -8,8 +8,27 @@
 #include "xstate/xstate.h"
 #include "xstate/xtoken.h"
 #include "xstate/xunit_state_fwd.h"
+
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wpedantic"
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wpedantic"
+#elif defined(_MSC_VER)
+#    pragma warning(push, 0)
+#endif
+
 #include "xvledger/xvaccount.h"
 #include "xvledger/xvproperty.h"
+
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#    pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#    pragma warning(pop)
+#endif
 
 #include <cstdint>
 

--- a/src/xtopcom/xstate/xunit_state.h
+++ b/src/xtopcom/xstate/xunit_state.h
@@ -4,24 +4,24 @@
 
 #pragma once
 
+#include "xbase/xobject_ptr.h"
 #include "xstate/xstate.h"
 #include "xstate/xtoken.h"
 #include "xstate/xunit_state_fwd.h"
 #include "xvledger/xvaccount.h"
+#include "xvledger/xvproperty.h"
 
 #include <cstdint>
 
 NS_BEG2(top, state)
 
-using xtoken_t = uint64_t;
-using xnonce_t = uint64_t;
-
 class xtop_unit_state : public xstate_t {
 public:
-    base::xvaccount_t address() const = 0;
-    virtual xtoken_t balance() const noexcept = 0;
-    virtual xnonce_t nonce() const noexcept = 0;
-    virtual xtoken_t locked_balance() const noexcept = 0;
+    virtual base::xvaccount_t address() const = 0;
+    virtual uint64_t balance() const noexcept = 0;
+    virtual uint64_t nonce() const noexcept = 0;
+    virtual uint64_t locked_balance() const noexcept = 0;
+    virtual xobject_ptr_t<base::xdataunit_t> get_property(std::string const & property_name) const = 0;
 };
 
 NS_END2

--- a/src/xtopcom/xstate/xunit_state_fwd.h
+++ b/src/xtopcom/xstate/xunit_state_fwd.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2017-2021 Telos Foundation & contributors
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#pragma once
+
+#include "xbase/xns_macro.h"
+
+
+NS_BEG2(top, state)
+
+class xtop_unit_state;
+using xunit_state_t = xtop_unit_state;
+
+NS_END2

--- a/src/xtopcom/xvledger/xdataobj_base.hpp
+++ b/src/xtopcom/xvledger/xdataobj_base.hpp
@@ -57,7 +57,7 @@ enum enum_xtopcom_object_type {
 };
 
 
-template <typename T, int type_value>
+template <typename T, enum_xtopcom_object_type type_value>
 class xbase_dataobj_t : public base::xdataobj_t {
  protected:
     enum { object_type_value = enum_xdata_type_max - type_value };

--- a/tests/xbasic/src/test_serializable_based_on.cpp
+++ b/tests/xbasic/src/test_serializable_based_on.cpp
@@ -97,6 +97,17 @@ TEST(serializable, read_old_data1) {
     EXPECT_EQ(expected.i, actual.i);
     EXPECT_EQ(expected.j, actual.j);
     EXPECT_EQ(expected.next, actual.next);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    old_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_EQ(expected.next, actual2.next);
 }
 
 TEST(serializable, read_old_data2) {
@@ -118,6 +129,19 @@ TEST(serializable, read_old_data2) {
     EXPECT_TRUE(actual.next != nullptr);
     EXPECT_EQ(expected.next->i, actual.next->i);
     EXPECT_EQ(expected.next->j, actual.next->j);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    old_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next != nullptr);
+    EXPECT_EQ(expected.next->i, actual2.next->i);
+    EXPECT_EQ(expected.next->j, actual2.next->j);
 }
 
 TEST(serializable, new_read_old_data1) {
@@ -140,6 +164,20 @@ TEST(serializable, new_read_old_data1) {
     EXPECT_TRUE(actual.pre == nullptr);
     EXPECT_EQ(expected.next->i, actual.next->i);
     EXPECT_EQ(expected.next->j, actual.next->j);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    new_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next != nullptr);
+    EXPECT_TRUE(actual2.pre == nullptr);
+    EXPECT_EQ(expected.next->i, actual2.next->i);
+    EXPECT_EQ(expected.next->j, actual2.next->j);
 }
 
 TEST(serializable, new_read_old_data2) {
@@ -157,6 +195,18 @@ TEST(serializable, new_read_old_data2) {
     EXPECT_EQ(expected.j, actual.j);
     EXPECT_TRUE(actual.next == nullptr);
     EXPECT_TRUE(actual.pre == nullptr);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    new_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next == nullptr);
+    EXPECT_TRUE(actual2.pre == nullptr);
 }
 
 TEST(serializable, old_read_new_data1) {
@@ -173,6 +223,17 @@ TEST(serializable, old_read_new_data1) {
     EXPECT_EQ(expected.i, actual.i);
     EXPECT_EQ(expected.j, actual.j);
     EXPECT_TRUE(actual.next == nullptr);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    old_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next == nullptr);
 }
 
 TEST(serializable, old_read_new_data2) {
@@ -200,6 +261,22 @@ TEST(serializable, old_read_new_data2) {
     EXPECT_TRUE(expected.next->next != nullptr);
     EXPECT_EQ(expected.next->next->i, actual.next->next->i);
     EXPECT_EQ(expected.next->next->j, actual.next->next->j);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    old_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next != nullptr);
+    EXPECT_EQ(expected.next->i, actual2.next->i);
+    EXPECT_EQ(expected.next->j, actual2.next->j);
+    EXPECT_TRUE(expected.next->next != nullptr);
+    EXPECT_EQ(expected.next->next->i, actual2.next->next->i);
+    EXPECT_EQ(expected.next->next->j, actual2.next->next->j);
 }
 
 TEST(serializable, old_read_new_data3) {
@@ -230,4 +307,31 @@ TEST(serializable, old_read_new_data3) {
     EXPECT_TRUE(expected.next->next != nullptr);
     EXPECT_EQ(expected.next->next->i, actual.next->next->i);
     EXPECT_EQ(expected.next->next->j, actual.next->next->j);
+
+    std::error_code ec;
+    auto bytes = expected.serialize_based_on<top::base::xstream_t>(ec);
+    EXPECT_EQ(0, ec.value());
+
+    old_data actual2;
+    actual2.deserialize_based_on<top::base::xstream_t>(bytes, ec);
+    EXPECT_EQ(0, ec.value());
+    EXPECT_EQ(expected.i, actual2.i);
+    EXPECT_EQ(expected.j, actual2.j);
+    EXPECT_TRUE(actual2.next != nullptr);
+    EXPECT_EQ(expected.next->i, actual2.next->i);
+    EXPECT_EQ(expected.next->j, actual2.next->j);
+    EXPECT_TRUE(expected.next->next != nullptr);
+    EXPECT_EQ(expected.next->next->i, actual2.next->next->i);
+    EXPECT_EQ(expected.next->next->j, actual2.next->next->j);
+}
+
+TEST(serializable, deserialize_from_invalid_input) {
+    std::error_code ec;
+    top::xbyte_buffer_t empty_bytes;
+
+    EXPECT_NO_THROW(
+        old_data data;
+        data.deserialize_based_on<top::base::xstream_t>(empty_bytes, ec);
+    );
+    EXPECT_NE(0, ec.value());
 }

--- a/tests/xblockstore2_test/CMakeLists.txt
+++ b/tests/xblockstore2_test/CMakeLists.txt
@@ -10,6 +10,8 @@ add_dependencies(xblockstore2_test xblockstore)
 include_directories(src/xtopcom/xblockstore/)
 target_link_libraries(xblockstore2_test PRIVATE
     xblockstore
+    xdata
+    xcommon
     gtest
 )
 


### PR DESCRIPTION
1. enable xblockchain2_t's execute_block functionality.
2. enrich xserializable_base_on & corresponding tests.