### PR TITLE
fix(blockstore xbft): fix connect data

### DIFF
--- a/src/xtopcom/xBFT/src/xconsaccount.cpp
+++ b/src/xtopcom/xBFT/src/xconsaccount.cpp
@@ -149,7 +149,8 @@ namespace top
                 xwarn("xcsaccount_t::on_pdu_event_down,wrong dest address(%llu) at node=%llu",get_xip2_addr().low_addr,get_xip2_low_addr());
                 _evt_obj->set_to_xip(get_xip2_addr());//correct target address to make sure it always be this address
             }
-            if(_evt_obj->_packet.get_msg_type() == enum_consensus_msg_type_proposal) //replica get proposal from leader
+            if(   (_evt_obj->_packet.get_msg_type() == enum_consensus_msg_type_proposal) //replica get proposal from leader
+               || (_evt_obj->_packet.get_msg_type() == enum_consensus_msg_type_commit) ) //try sync first for commit msg
             {
                 if(get_child_node() != NULL)
                 {

--- a/src/xtopcom/xBFT/src/xconscontext.cpp
+++ b/src/xtopcom/xBFT/src/xconscontext.cpp
@@ -487,13 +487,11 @@ namespace top
                     else //new_cert_block might be duplicated or behind commit block as well
                     {
                         xwarn("xBFTcontext_t::on_proposal_finish,drop proposal as false as do_update for block:%s at node=0x%llx",new_cert_block->dump().c_str(),get_xip2_addr().low_addr);
-                        return true; //stop handle this proposal
                     }
                 }
                 else
                 {
-                    xerror("xBFTcontext_t::on_proposal_finish,fail-safe_check_for_block for block:%s at node=0x%llx",new_cert_block->dump().c_str(),get_xip2_addr().low_addr);
-                    return true; //stop handle this error proposal
+                    xwarn("xBFTcontext_t::on_proposal_finish,fail-safe_check_for_block for block:%s at node=0x%llx",new_cert_block->dump().c_str(),get_xip2_addr().low_addr);
                 }
             }
     
@@ -574,13 +572,11 @@ namespace top
                     else //new_cert_block might be duplicated or behind commit block as well
                     {
                         xwarn("xBFTcontext_t::on_replicate_finish,drop cert as false as do_update for block:%s at node=0x%llx",new_cert_block->dump().c_str(),get_xip2_addr().low_addr);
-                        return true; //stop handle this proposal
                     }
                 }
                 else
                 {
-                    xerror("xBFTcontext_t::on_replicate_finish,fail-safe_check_for_block for block:%s at node=0x%llx",new_cert_block->dump().c_str(),get_xip2_addr().low_addr);
-                    return true; //stop handle this error proposal
+                    xwarn("xBFTcontext_t::on_replicate_finish,fail-safe_check_for_block for block:%s at node=0x%llx",new_cert_block->dump().c_str(),get_xip2_addr().low_addr);
                 }
                 
                 //go default handle ,bring latest information of commit and lock

--- a/src/xtopcom/xblockstore/src/xvblockhub.h
+++ b/src/xtopcom/xblockstore/src/xvblockhub.h
@@ -172,7 +172,7 @@ namespace top
             base::xvbindex_t*      load_latest_committed_index();   //block with committed status
             base::xvbindex_t*      load_latest_executed_index();    //block with executed status
             base::xvbindex_t*      load_latest_connected_index();   //block has connected to the last full
-            base::xvbindex_t*      load_latest_genesis_connected_index();  //block has connected to genesis;
+            base::xvbindex_t*      load_latest_genesis_connected_index(bool ask_full_search);  //block has connected to genesis;
             base::xvbindex_t*      load_latest_full_index();        //block has full state,genesis is a full block
             base::xvbindex_t*      load_latest_committed_full_index();  // full block with committed status
  
@@ -222,7 +222,7 @@ namespace top
             bool                write_block_output_to_db(base::xvbindex_t* index_ptr,base::xvblock_t * block_ptr);
             bool                read_block_output_from_db(base::xvbindex_t* index_ptr);
             bool                read_block_output_from_db(base::xvblock_t * block_ptr);
-            
+                 
             //manage data related xvboffdata_t
             bool                write_block_offdata_to_db(base::xvbindex_t* index_ptr,base::xvblock_t * block_ptr);
             bool                read_block_offdata_from_db(base::xvblock_t * block_ptr);

--- a/src/xtopcom/xblockstore/src/xvunithub.cpp
+++ b/src/xtopcom/xblockstore/src/xvunithub.cpp
@@ -164,10 +164,16 @@ namespace top
             return load_block_from_index(account_obj.get(),account_obj->load_latest_connected_index(),0,false);
         }
 
-        base::xauto_ptr<base::xvblock_t>    xvblockstore_impl::get_latest_genesis_connected_block(const base::xvaccount_t & account)//block has connected to genesis
+        base::xauto_ptr<base::xvblock_t>    xvblockstore_impl::get_latest_genesis_connected_block(const base::xvaccount_t & account,bool ask_full_search)//block has connected to genesis
         {
             LOAD_BLOCKACCOUNT_PLUGIN(account_obj,account);
-            return load_block_from_index(account_obj.get(),account_obj->load_latest_genesis_connected_index(),0,false);
+            return load_block_from_index(account_obj.get(),account_obj->load_latest_genesis_connected_index(ask_full_search),0,false);
+        }
+    
+        base::xauto_ptr<base::xvbindex_t> xvblockstore_impl::get_latest_genesis_connected_index(const base::xvaccount_t & account,bool ask_full_search) //block has connected to genesis
+        {
+            LOAD_BLOCKACCOUNT_PLUGIN(account_obj,account);
+            return account_obj->load_latest_genesis_connected_index(ask_full_search);
         }
 
         base::xauto_ptr<base::xvblock_t>  xvblockstore_impl::get_latest_full_block(const base::xvaccount_t & account)

--- a/src/xtopcom/xblockstore/src/xvunithub.h
+++ b/src/xtopcom/xblockstore/src/xvunithub.h
@@ -53,7 +53,8 @@ namespace top
             virtual base::xauto_ptr<base::xvblock_t>  get_latest_committed_block(const base::xvaccount_t & account)override;
             virtual base::xauto_ptr<base::xvblock_t>  get_latest_executed_block(const base::xvaccount_t & account) override;
             virtual base::xauto_ptr<base::xvblock_t>  get_latest_connected_block(const base::xvaccount_t & account)override;
-            virtual base::xauto_ptr<base::xvblock_t>  get_latest_genesis_connected_block(const base::xvaccount_t & account) override; //block has connected to genesis
+            virtual base::xauto_ptr<base::xvblock_t>  get_latest_genesis_connected_block(const base::xvaccount_t & account,bool ask_full_search) override; //block has connected to genesis
+            virtual base::xauto_ptr<base::xvbindex_t> get_latest_genesis_connected_index(const base::xvaccount_t & account,bool ask_full_search) override; //block has connected to genesis
             virtual base::xauto_ptr<base::xvblock_t>  get_latest_full_block(const base::xvaccount_t & account) override;
             virtual base::xauto_ptr<base::xvblock_t>  get_latest_committed_full_block(const base::xvaccount_t & account) override;
 

--- a/src/xtopcom/xblockstore/test/basic/main.cpp
+++ b/src/xtopcom/xblockstore/test/basic/main.cpp
@@ -32,7 +32,7 @@ namespace top
 
 //#define __portional_random__
 #define __full_random__
-#define __fork_test__
+//#define __fork_test__
 //#define __execute_test__
 int test_sync_vstore(store::xsyncvstore_t* sync_store)
 {
@@ -160,8 +160,11 @@ int test_sync_vstore(store::xsyncvstore_t* sync_store)
 #endif //end of __execute_test__
     
     sleep(2);
-    
+
     printf("////////////////////////////////////////////////////////////// \n");
+    base::xauto_ptr<base::xvbindex_t> index(sync_store->get_vblockstore()->get_latest_genesis_connected_index(test_account_obj,true));
+    printf("latest_genesis_connected_index as detail=%s \n",index->dump().c_str());
+    
     for(auto it : generated_blocks)
     {
         base::xauto_ptr<base::xvbindex_t> index(sync_store->get_vblockstore()->load_block_index(test_account_obj, it->get_height(), 0));

--- a/src/xtopcom/xvledger/xvblockstore.h
+++ b/src/xtopcom/xvledger/xvblockstore.h
@@ -125,6 +125,7 @@ namespace top
             std::vector<xvblock_t*> m_vector;
         };
 
+
         //manage/connect "virtual block" with "virtual header",usally it implement based on xvblocknode_t
         //note: each chain may has own block store by assined different store_path at DB/disk
         class xvblockstore_t : public xiobject_t
@@ -159,7 +160,8 @@ namespace top
             virtual xauto_ptr<xvblock_t>  get_latest_committed_block(const xvaccount_t & account)  = 0;//block with committed status
             virtual xauto_ptr<xvblock_t>  get_latest_executed_block(const xvaccount_t & account)   = 0;//block with executed status
             virtual xauto_ptr<xvblock_t>  get_latest_connected_block(const xvaccount_t & account)  = 0;//block connected to genesis or fullblock
-            virtual xauto_ptr<xvblock_t>  get_latest_genesis_connected_block(const xvaccount_t & account) = 0; //block has connected to genesis
+            virtual xauto_ptr<xvblock_t>  get_latest_genesis_connected_block(const xvaccount_t & account,bool ask_full_search = true) = 0; //block has connected to genesis
+            virtual xauto_ptr<xvbindex_t> get_latest_genesis_connected_index(const xvaccount_t & account,bool ask_full_search = true) = 0; //block has connected to genesis
 
             virtual xauto_ptr<xvblock_t>  get_latest_full_block(const xvaccount_t & account)  = 0; //block has full state,genesis is a full block
             virtual xauto_ptr<xvblock_t>  get_latest_committed_full_block(const xvaccount_t & account)  = 0; // full block with committed status, genesis is a full block

--- a/tests/xvledger_test/xdummy_blockstore.h
+++ b/tests/xvledger_test/xdummy_blockstore.h
@@ -54,7 +54,7 @@ public:
         return nullptr;
     }
 
-    base::xauto_ptr<base::xvblock_t> get_latest_genesis_connected_block(const base::xvaccount_t & account, bool ask_full_search = true) override {
+    base::xauto_ptr<base::xvblock_t> get_latest_genesis_connected_block(const base::xvaccount_t & account, bool ask_full_search) override {
         return nullptr;
     }
 

--- a/tests/xvledger_test/xdummy_blockstore.h
+++ b/tests/xvledger_test/xdummy_blockstore.h
@@ -54,7 +54,7 @@ public:
         return nullptr;
     }
 
-    base::xauto_ptr<base::xvblock_t> get_latest_genesis_connected_block(const base::xvaccount_t & account) override {
+    base::xauto_ptr<base::xvblock_t> get_latest_genesis_connected_block(const base::xvaccount_t & account, bool ask_full_search = true) override {
         return nullptr;
     }
 

--- a/tests/xvledger_test/xdummy_blockstore.h
+++ b/tests/xvledger_test/xdummy_blockstore.h
@@ -57,6 +57,10 @@ public:
     base::xauto_ptr<base::xvblock_t> get_latest_genesis_connected_block(const base::xvaccount_t & account, bool ask_full_search) override {
         return nullptr;
     }
+    
+    base::xauto_ptr<base::xvbindex_t> get_latest_genesis_connected_index(const base::xvaccount_t & account,bool ask_full_search) override {
+        return nullptr;
+    }
 
     base::xauto_ptr<base::xvblock_t> get_latest_committed_full_block(const base::xvaccount_t & account) override {
         return nullptr;


### PR DESCRIPTION
body:
 1. extend get_latest_genesis_connected_block(bool ask_full_search) do fully search until to _highest_commit_block_height
 2. add get_latest_genesis_connected_index() with better performance for sync-module
 3. allow store any block that pulled from xbft driver