### PR TITLE
feat(tools): add leak_tracer tools && build_option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,10 @@ if (BUILD_RUSTVM)
     add_definitions(-DBUILD_RUSTVM)
 endif()
 
+if (LEAK_TRACER)
+    add_definitions(-DLEAK_TRACER)
+endif()
+
 if (${CMAKE_SYSTEM_NAME} STREQUAL Linux OR ${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
 #  find_package(PkgConfig REQUIRED)
 

--- a/build_options.sh
+++ b/build_options.sh
@@ -117,6 +117,10 @@ do
         CMAKE_EXTRA_OPTIONS+=" -DBUILD_RUSTVM=ON"
         echo "BUILD RUSTVM(need cargo toolchain)"
     ;;
+    leak_trace)
+        CMAKE_EXTRA_OPTIONS+=" -DLEAK_TRACER=ON"
+        echo "BUILD WITH LEAK_TRACER tool"
+    ;;
     *)
         CMAKE_EXTRA_OPTIONS=" -DXENABLE_TESTS=OFF -DXENABLE_CODE_COVERAGE=OFF"
     ;;

--- a/src/libraries/CMakeLists.txt
+++ b/src/libraries/CMakeLists.txt
@@ -7,3 +7,6 @@ add_subdirectory(xchaininit)
 add_subdirectory(xsync)
 add_subdirectory(xgrpc_mgr)
 
+if (LEAK_TRACER)
+add_subdirectory(leaktracer)
+endif()

--- a/src/libraries/leaktracer/CMakeLists.txt
+++ b/src/libraries/leaktracer/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.8)
+
+add_definitions(-DUSE_BACKTRACE)
+include_directories(.)
+
+aux_source_directory(./src leaktracer_src)
+add_library(leaktracer STATIC ${leaktracer_src})

--- a/src/libraries/leaktracer/LeakTracer_l.hpp
+++ b/src/libraries/leaktracer/LeakTracer_l.hpp
@@ -1,0 +1,14 @@
+#ifndef __LEAKTRACE_L_h_included__
+#define __LEAKTRACE_L_h_included__
+
+#ifndef TRACE
+#ifdef LOGGER
+#define TRACE(arg) fprintf arg
+#else
+#define TRACE(arg)
+#endif
+#endif
+
+#define LEAKTRACER_VERSION "3.0.0"
+
+#endif /* __LEAKTRACE_L_h_included__ */

--- a/src/libraries/leaktracer/MapMemoryInfo.hpp
+++ b/src/libraries/leaktracer/MapMemoryInfo.hpp
@@ -1,0 +1,247 @@
+////////////////////////////////////////////////////////
+//
+// LeakTracer
+// Contribution to original project by Erwin S. Andreasen
+// site: http://www.andreasen.org/LeakTracer/
+//
+// Added by Michael Gopshtein, 2006
+// mgopshtein@gmail.com
+//
+// Any comments/suggestions are welcome
+//
+////////////////////////////////////////////////////////
+
+#ifndef __MAP_MEMORY_INFO_h_included__
+#define __MAP_MEMORY_INFO_h_included__
+
+#include "ObjectsPool.hpp"
+
+
+namespace leaktracer {
+
+/**
+ * Help class, holds all relevant information for each
+ * allocation (logically it's a map of void* address to
+ * structure with required info)
+ */
+template <typename T>
+class TMapMemoryInfo {
+public:
+	TMapMemoryInfo(void);
+	virtual ~TMapMemoryInfo(void) {}
+
+	/** Allocates sizeof(T) buffer, and associates it with given
+	 *  poiter */
+	inline T * insert(void *ptr);
+
+	/** Returns pointer to T object, associated with given pointer */
+	inline T * find(void *ptr);
+
+	/** Releases a buffer, associated with given pointer. */
+	inline void release(void *ptr);
+
+	/** Following 2 functions used for iteration over all
+	 *  elements */
+	void beginIteration(void);
+	bool getNextPair(T **ppObject, void **pptr);
+	bool empty(void);
+
+	void clearAllInfo(void);
+
+private:
+	// hash function from pointer to int (range is defined by POINTER_HASH_LENGTH static)
+	inline unsigned long hash(void *ptr);
+
+	// defines single pointer's info
+	typedef struct _pointer_info_struct {
+		void *ptr;
+		T info;
+	} pointer_info_t;
+
+	// list node - to hold list of all info's having same hash value
+	typedef struct _list_node_struct {
+		pointer_info_t pinfo;
+		struct _list_node_struct *next;
+	} list_node_t;
+
+	// array of lists (according to hash function)
+#define POINTER_HASH_LENGTH				16
+#define NUMBER_OF_MEMORY_INFO_LISTS		(1 << POINTER_HASH_LENGTH)
+	list_node_t * __info_lists[NUMBER_OF_MEMORY_INFO_LISTS];
+
+	// memory allocation - using a pool
+#define DEFAULT_NUMBER_OF_ELEMENTS_IN_CHUNK (1 << 12)
+	typedef TObjectsPool<list_node_t, DEFAULT_NUMBER_OF_ELEMENTS_IN_CHUNK> nodes_pool_t;
+	nodes_pool_t __pool;
+
+	// current position in iteration
+	long __lIterationCurrentListIndex;
+	list_node_t *__pIterationCurrentElement;
+};
+
+
+//////////////////////////////////////////////////////////////////////
+//
+// IMPLEMENTATION: TMapMemoryInfo
+// (inline template functions)
+//
+//////////////////////////////////////////////////////////////////////
+
+template <typename T>
+TMapMemoryInfo<T>::TMapMemoryInfo(void)
+{
+	// initializes all lists to be empty
+	for( int i = 0; i < NUMBER_OF_MEMORY_INFO_LISTS; i++ )
+		__info_lists[i] = NULL;
+
+	// members used for iteration
+	__lIterationCurrentListIndex = -1;
+	__pIterationCurrentElement = NULL;
+}
+
+template <typename T>
+inline unsigned long TMapMemoryInfo<T>::hash(void *ptr)
+{ return (reinterpret_cast<unsigned long>(ptr) & (NUMBER_OF_MEMORY_INFO_LISTS - 1)); }
+
+template <typename T>
+inline T * TMapMemoryInfo<T>::insert(void *ptr)
+{
+	list_node_t * pNew = static_cast<list_node_t*>(__pool.allocate());
+	if( !pNew )
+		return NULL;
+
+	// insert to the "hash(ptr)" list
+	long key = hash(ptr);
+	pNew->next = __info_lists[key];
+	__info_lists[key] = pNew;
+
+	(pNew->pinfo).ptr = ptr;
+	return &((pNew->pinfo).info);
+}
+
+
+template <typename T>
+inline T * TMapMemoryInfo<T>::find(void *ptr)
+{
+	list_node_t * pNext = __info_lists[hash(ptr)];
+	while( pNext != NULL )
+	{
+		if( (pNext->pinfo).ptr == ptr )
+			return &((pNext->pinfo).info);
+		pNext = pNext->next;
+	}
+
+	// not found
+	return NULL;
+}
+
+
+template <typename T>
+inline void TMapMemoryInfo<T>::release(void *ptr)
+{
+	long key = hash(ptr);
+	list_node_t * pNext = __info_lists[key];
+	if( NULL == pNext )
+		// list is empty
+		return;
+
+	if( (pNext->pinfo).ptr == ptr )
+	{
+		// found: is a first element
+		__info_lists[key] = pNext->next;
+		__pool.release(pNext);
+		return;
+	}
+
+	// searching in other elements
+	list_node_t * pPrev = pNext;
+	pNext = pNext->next;
+
+	while( pNext != NULL)
+	{
+		if( (pNext->pinfo).ptr == ptr )
+		{
+			pPrev->next = pNext->next;
+			__pool.release( pNext );
+			return;
+		}
+		pPrev = pNext;
+		pNext = pNext->next;
+	}
+}
+
+
+template <typename T>
+void TMapMemoryInfo<T>::beginIteration(void)
+{
+	__lIterationCurrentListIndex = 0;
+	__pIterationCurrentElement = __info_lists[0];
+}
+
+
+//---------------------------------
+// returns next pair (element, pointer) as output parameters
+// returns false if no more elements
+template <typename T>
+bool TMapMemoryInfo<T>::getNextPair(T **ppObject, void **pptr)
+{
+	if( NULL == __pIterationCurrentElement )
+	{
+		// current list ended, should find next non-empty list
+		while (__lIterationCurrentListIndex < NUMBER_OF_MEMORY_INFO_LISTS &&
+			   NULL == __pIterationCurrentElement)
+		{
+			__lIterationCurrentListIndex ++;
+			__pIterationCurrentElement = __info_lists[__lIterationCurrentListIndex];
+		}
+
+		if (__lIterationCurrentListIndex == NUMBER_OF_MEMORY_INFO_LISTS)
+		{
+			// reached the end of the lists
+			*ppObject = NULL;
+			*pptr = NULL;
+			return false;
+		}
+
+	}
+
+	*ppObject = &(__pIterationCurrentElement->pinfo.info);
+	*pptr = __pIterationCurrentElement->pinfo.ptr;
+
+	// advise "current element" to be the next element in current list
+	__pIterationCurrentElement = __pIterationCurrentElement->next;
+
+	return true;
+}
+
+template <typename T>
+bool TMapMemoryInfo<T>::empty(void)
+{
+	for (long l = 0; l < NUMBER_OF_MEMORY_INFO_LISTS; l++) {
+		list_node_t * pNext = __info_lists[l];
+		if (pNext != NULL){
+			return false;
+		}
+	}
+	return true;
+}
+
+
+template <typename T>
+void TMapMemoryInfo<T>::clearAllInfo(void)
+{
+	for (long l = 0; l < NUMBER_OF_MEMORY_INFO_LISTS; l++) {
+		list_node_t * pNext = __info_lists[l];
+		while (pNext != NULL) {
+			__info_lists[l] = pNext->next;
+			__pool.release(pNext);
+			pNext = __info_lists[l];
+		}
+	}
+}
+
+
+}  // end namespace
+
+
+#endif  // include once

--- a/src/libraries/leaktracer/MemoryTrace.hpp
+++ b/src/libraries/leaktracer/MemoryTrace.hpp
@@ -1,0 +1,423 @@
+////////////////////////////////////////////////////////
+//
+// LeakTracer
+// Contribution to original project by Erwin S. Andreasen
+// site: http://www.andreasen.org/LeakTracer/
+//
+// Added by Michael Gopshtein, 2006
+// mgopshtein@gmail.com
+//
+// Any comments/suggestions are welcome
+//
+////////////////////////////////////////////////////////
+
+#ifndef __MEMORY_TRACE_h_included__
+#define __MEMORY_TRACE_h_included__
+
+#include <time.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <iostream>
+#include <list>
+#ifdef USE_BACKTRACE
+#include <execinfo.h>
+#endif
+
+
+#include "Mutex.hpp"
+#include "MutexLock.hpp"
+#include "MapMemoryInfo.hpp"
+
+
+/////////////////////////////////////////////////////////////
+// Following MACROS are available at compile time:
+//
+// START_TRACING_FROM_PROCESS_START - starts monitoring memory
+//              allocations from the start of BeatBox process.
+//              Otherwise should be explicetly activated
+//              default: OFF
+//
+// ALLOCATION_STACK_DEPTH - max number of stack frame to
+//              save. Max supported value: 10
+//
+// PRINTED_DATA_BUFFER_SIZE - size of the data buffer to be printed
+//              for each allocation.
+//
+/////////////////////////////////////////////////////////////
+
+#ifndef ALLOCATION_STACK_DEPTH
+#	define ALLOCATION_STACK_DEPTH 50
+#endif
+
+#ifndef PRINTED_DATA_BUFFER_SIZE
+#	define PRINTED_DATA_BUFFER_SIZE 50
+#endif
+#include "LeakTracer_l.hpp"
+
+
+namespace leaktracer {
+
+
+/**
+ * Main class to trace memory allocations
+ * and releases.
+ */
+class MemoryTrace {
+public:
+	/** singleton class */
+	inline static MemoryTrace & GetInstance(void);
+
+	/** setup undelying libc malloc/free... */
+	static int Setup(void);
+
+	/** starts monitoring memory allocations in all threads */
+	inline void startMonitoringAllThreads(void);
+	/** starts monitoring memory allocations in current thread */
+	inline void startMonitoringThisThread(void);
+
+	/** stops monitoring memory allocations (in all threads or in
+	 *   this thread only, depends on the function used to start
+	 *   monitoring */
+	inline void stopMonitoringAllocations(void);
+
+	/** stops all monitoring - both of allocations and releases */
+	inline void stopAllMonitoring(void);
+
+	/** registers new memory allocation, should be called by the
+	 *  function intercepting "new" calls */
+	inline void registerAllocation(void *p, size_t size, bool is_array);
+
+	/** registers memory reallocation, should be called by the
+	 *  function intercepting realloc calls */
+	inline void registerReallocation(void *p, size_t size, bool is_array);
+
+	/** registers memory release, should be called by the
+	 *  function intercepting "delete" calls */
+	inline void registerRelease(void *p, bool is_array);
+
+	/** writes report with all memory leaks */
+	void writeLeaks(std::ostream &out);
+
+	/** writes report with all memory leaks */
+	void writeLeaksToFile(const char* reportFileName);
+
+	/** returns TRUE if all monitoring is currently disabled,
+	 *  required to make sure we don't use this class before it
+	 *  was properly initialized */
+	inline bool AllMonitoringIsDisabled(void) {
+		return ( (__monitoringDisabler!=0)||
+			 (((intptr_t)pthread_getspecific(__thread_internal_disabler_key)) != 0) );
+	}
+
+	inline int InternalMonitoringDisablerThreadUp(void) {
+		intptr_t oldvalue;
+		oldvalue = (intptr_t)pthread_getspecific(__thread_internal_disabler_key);
+		//TRACE((stderr, "InternalMonitoringDisablerThreadUp oldvalue %d\n", oldvalue));
+		pthread_setspecific(__thread_internal_disabler_key, (void*) (oldvalue + 1) );
+		return oldvalue;
+	}
+
+	inline int InternalMonitoringDisablerThreadDown(void) {
+		intptr_t oldvalue;
+		oldvalue = (intptr_t)pthread_getspecific(__thread_internal_disabler_key);
+		//TRACE((stderr, "InternalMonitoringDisablerThreadDown oldvalue %d\n", oldvalue));
+		pthread_setspecific(__thread_internal_disabler_key, (void*) (oldvalue - 1) );
+		return oldvalue;
+	}
+
+	static void __attribute__ ((constructor)) MemoryTraceOnInit(void);
+	static void __attribute__ ((destructor)) MemoryTraceOnExit(void);
+
+	/** destructor */
+	virtual ~MemoryTrace(void);
+
+private:
+	// singleton object
+	MemoryTrace(void);
+	static MemoryTrace *__instance;
+
+	// global settings
+	bool __setupDone;
+	bool __monitoringAllThreads;
+	bool __monitoringReleases;
+	int  __monitoringDisabler;
+
+	// per-thread settings, for cases where only allocations
+	// made by specific threads are monitored
+	struct ThreadMonitoringOptions {
+		bool monitoringAllocations;
+		inline ThreadMonitoringOptions() : monitoringAllocations(false) {}
+	};
+	inline ThreadMonitoringOptions & getThreadOptions(void);
+	void removeThreadOptions(ThreadMonitoringOptions *pOptions);
+	inline void stopMonitoringPerThreadAllocations(void);
+
+	// key to access per-thread info
+	pthread_key_t __thread_internal_disabler_key;
+
+	static void CleanUpThreadData(void *ptrThreadOptions);
+	pthread_key_t __thread_options_key;
+
+	// init functions
+	static void init_no_alloc_allowed();
+	static pthread_once_t _init_no_alloc_allowed_once;
+
+	void init_full();
+	static void init_full_from_once();
+	static pthread_once_t _init_full_once;
+
+	// signal handler
+	static int __sigStartAllThread;
+	static int __sigStopAllThread;
+	static int __sigReport;
+	static void sigactionHandler(int, siginfo_t *, void *);
+	static int signalNumberFromString(const char* signame);
+
+	/** writes report with all memory leaks */
+	void writeLeaksPrivate(std::ostream &out);
+
+	// centralized list of all per-thread options
+	typedef std::list<ThreadMonitoringOptions*> list_monitoring_options_t;
+	list_monitoring_options_t __listThreadOptions;
+	Mutex __threadListMutex;
+
+	// per - allocation info
+	typedef struct _allocation_info_struct {
+		size_t size;
+		struct timespec timestamp;
+		void * allocStack[ALLOCATION_STACK_DEPTH];
+		bool isArray;
+	} allocation_info_t;
+	inline void storeAllocationStack(void* arr[ALLOCATION_STACK_DEPTH]);
+	inline void storeTimestamp(struct timespec &tm);
+
+	typedef TMapMemoryInfo<allocation_info_t> memory_allocations_info_t;
+	memory_allocations_info_t __allocations;
+	Mutex __allocations_mutex;
+	void clearAllocationsInfo(void);
+};
+
+
+
+//////////////////////////////////////////////////////////////////////
+//
+// IMPLEMENTATION: MemoryTrace
+// (inline functions)
+//
+//////////////////////////////////////////////////////////////////////
+
+
+// Returns singleton instance of MemoryTrace object
+inline MemoryTrace & MemoryTrace::GetInstance(void)
+{
+	return *__instance;
+}
+
+
+// Returns per-thread object for calling thread
+// (creates one if called for the first time)
+inline MemoryTrace::ThreadMonitoringOptions & MemoryTrace::getThreadOptions(void)
+{
+	ThreadMonitoringOptions *pOpt = reinterpret_cast<ThreadMonitoringOptions*>(pthread_getspecific(__thread_options_key));
+	if (pOpt == NULL) {
+		MutexLock lock(__threadListMutex);
+		// before creating new object we need to disable any monitoring
+		InternalMonitoringDisablerThreadUp();
+		pOpt = new ThreadMonitoringOptions;
+		pthread_setspecific(__thread_options_key, pOpt);
+		__listThreadOptions.push_back(pOpt);
+		InternalMonitoringDisablerThreadDown();
+	}
+	return *pOpt;
+}
+
+
+// iterates over list of per-thread objects, and diables
+// monitoring for all threads
+inline void MemoryTrace::stopMonitoringPerThreadAllocations(void)
+{
+	leaktracer::MemoryTrace::Setup();
+
+	MutexLock lock(__threadListMutex);
+	for (list_monitoring_options_t::iterator it = __listThreadOptions.begin(); it != __listThreadOptions.end(); ++it) {
+		(*it)->monitoringAllocations = false;
+	}
+}
+
+
+// starts monitoring allocations and releases in all threads
+inline void MemoryTrace::startMonitoringAllThreads(void)
+{
+	leaktracer::MemoryTrace::Setup();
+
+	TRACE((stderr, "LeakTracer: startMonitoringAllThreads\n"));
+	if (!__monitoringReleases) {
+		MutexLock lock(__allocations_mutex);
+		// double-check inside Mutex
+		if (!__monitoringReleases) {
+			__allocations.clearAllInfo();
+			__monitoringReleases = true;
+		}
+	}
+	__monitoringAllThreads = true;
+	stopMonitoringPerThreadAllocations();
+}
+
+
+// starts monitoring memory allocations in this thread
+// (note: releases are monitored in all threads)
+inline void MemoryTrace::startMonitoringThisThread(void)
+{
+	leaktracer::MemoryTrace::Setup();
+
+	TRACE((stderr, "LeakTracer: startMonitoringThisThread\n"));
+	if (!__monitoringAllThreads) {
+		if (!__monitoringReleases) {
+			MutexLock lock(__allocations_mutex);
+			// double-check inside Mutex
+			if (!__monitoringReleases) {
+				__allocations.clearAllInfo();
+				__monitoringReleases = true;
+			}
+		}
+		getThreadOptions().monitoringAllocations = true;
+	}
+}
+
+
+// Depending on "startMonitoring" function used previously,
+// will stop monitoring all threads, of current thread only
+inline void MemoryTrace::stopMonitoringAllocations(void)
+{
+	leaktracer::MemoryTrace::Setup();
+
+	TRACE((stderr, "LeakTracer: stopMonitoringAllocations\n"));
+	if (__monitoringAllThreads)
+		__monitoringAllThreads = false;
+	else
+		getThreadOptions().monitoringAllocations = false;
+}
+
+
+// stop all allocation/releases monitoring
+inline void MemoryTrace::stopAllMonitoring(void)
+{
+	leaktracer::MemoryTrace::Setup();
+
+	TRACE((stderr, "LeakTracer: stopAllMonitoring\n"));
+	stopMonitoringAllocations();
+	__monitoringReleases = false;
+}
+
+
+// stores allocation stack, up to ALLOCATION_STACK_DEPTH
+// frames
+inline void MemoryTrace::storeAllocationStack(void* arr[ALLOCATION_STACK_DEPTH])
+{
+	unsigned int iIndex = 0;
+#ifdef USE_BACKTRACE
+	void* arrtmp[ALLOCATION_STACK_DEPTH+1];
+	iIndex = backtrace(arrtmp, ALLOCATION_STACK_DEPTH + 1) - 1;
+	memcpy(arr, &arrtmp[1], iIndex*sizeof(void*));
+#else
+	void *pFrame;
+	// NOTE: we can't use "for" loop, __builtin_* functions
+	// require the number to be known at compile time
+	arr[iIndex++] = (                  (pFrame = __builtin_frame_address(0)) != NULL) ? __builtin_return_address(0) : NULL; if (iIndex == ALLOCATION_STACK_DEPTH) return;
+	arr[iIndex++] = (pFrame != NULL && (pFrame = __builtin_frame_address(1)) != NULL) ? __builtin_return_address(1) : NULL; if (iIndex == ALLOCATION_STACK_DEPTH) return;
+	arr[iIndex++] = (pFrame != NULL && (pFrame = __builtin_frame_address(2)) != NULL) ? __builtin_return_address(2) : NULL; if (iIndex == ALLOCATION_STACK_DEPTH) return;
+	arr[iIndex++] = (pFrame != NULL && (pFrame = __builtin_frame_address(3)) != NULL) ? __builtin_return_address(3) : NULL; if (iIndex == ALLOCATION_STACK_DEPTH) return;
+	arr[iIndex++] = (pFrame != NULL && (pFrame = __builtin_frame_address(4)) != NULL) ? __builtin_return_address(4) : NULL; if (iIndex == ALLOCATION_STACK_DEPTH) return;
+	arr[iIndex++] = (pFrame != NULL && (pFrame = __builtin_frame_address(5)) != NULL) ? __builtin_return_address(5) : NULL; if (iIndex == ALLOCATION_STACK_DEPTH) return;
+	arr[iIndex++] = (pFrame != NULL && (pFrame = __builtin_frame_address(6)) != NULL) ? __builtin_return_address(6) : NULL; if (iIndex == ALLOCATION_STACK_DEPTH) return;
+	arr[iIndex++] = (pFrame != NULL && (pFrame = __builtin_frame_address(7)) != NULL) ? __builtin_return_address(7) : NULL; if (iIndex == ALLOCATION_STACK_DEPTH) return;
+	arr[iIndex++] = (pFrame != NULL && (pFrame = __builtin_frame_address(8)) != NULL) ? __builtin_return_address(8) : NULL; if (iIndex == ALLOCATION_STACK_DEPTH) return;
+	arr[iIndex++] = (pFrame != NULL && (pFrame = __builtin_frame_address(9)) != NULL) ? __builtin_return_address(9) : NULL;
+#endif
+	// fill remaining spaces
+	for (; iIndex < ALLOCATION_STACK_DEPTH; iIndex++)
+		arr[iIndex] = NULL;
+}
+
+
+// adds all relevant info regarding current allocation to map
+inline void MemoryTrace::registerAllocation(void *p, size_t size, bool is_array)
+{
+	allocation_info_t *info = NULL;
+	if (!AllMonitoringIsDisabled() && (__monitoringAllThreads || getThreadOptions().monitoringAllocations) && p != NULL) {
+		MutexLock lock(__allocations_mutex);
+		info = __allocations.insert(p);
+		if (info != NULL) {
+			info->size = size;
+			info->isArray = is_array;
+			storeTimestamp(info->timestamp);
+		}
+	}
+ 	// we store the stack without locking __allocations_mutex
+	// it should be safe enough
+	// prevent a deadlock between backtrave function who are now using advanced dl_iterate_phdr function
+ 	// and dl_* function which uses malloc functions
+	if (info != NULL) {
+		storeAllocationStack(info->allocStack);
+	}
+
+	if (p == NULL) {
+		InternalMonitoringDisablerThreadUp();
+		// WARNING
+		InternalMonitoringDisablerThreadDown();
+	}
+}
+
+
+// adds all relevant info regarding current allocation to map
+inline void MemoryTrace::registerReallocation(void *p, size_t size, bool is_array)
+{
+	if (!AllMonitoringIsDisabled() && (__monitoringAllThreads || getThreadOptions().monitoringAllocations) && p != NULL) {
+		MutexLock lock(__allocations_mutex);
+		allocation_info_t *info = __allocations.find(p);
+		if (info != NULL) {
+			info->size = size;
+			info->isArray = is_array;
+			storeAllocationStack(info->allocStack);
+			storeTimestamp(info->timestamp);
+		}
+	}
+
+	if (p == NULL) {
+		InternalMonitoringDisablerThreadUp();
+		// WARNING
+		InternalMonitoringDisablerThreadDown();
+	}
+}
+
+
+// removes allocation's info from the map
+inline void MemoryTrace::registerRelease(void *p, bool is_array)
+{
+	if (!AllMonitoringIsDisabled() && __monitoringReleases && p != NULL) {
+		MutexLock lock(__allocations_mutex);
+		allocation_info_t *info = __allocations.find(p);
+		if (info != NULL) {
+			if (info->isArray != is_array) {
+				InternalMonitoringDisablerThreadUp();
+				// WARNING
+				InternalMonitoringDisablerThreadDown();
+			}
+			__allocations.release(p);
+		}
+	}
+}
+
+// storetimestamp function
+inline void MemoryTrace::storeTimestamp(struct timespec &timestamp)
+{
+  clock_gettime(CLOCK_MONOTONIC, &timestamp);
+}
+
+
+}  // end namespace
+
+
+#endif  // include once

--- a/src/libraries/leaktracer/Mutex.hpp
+++ b/src/libraries/leaktracer/Mutex.hpp
@@ -1,0 +1,64 @@
+////////////////////////////////////////////////////////
+//
+// LeakTracer
+// Contribution to original project by Erwin S. Andreasen
+// site: http://www.andreasen.org/LeakTracer/
+//
+// Added by Michael Gopshtein, 2006
+// mgopshtein@gmail.com
+//
+// Any comments/suggestions are welcome
+//
+////////////////////////////////////////////////////////
+
+#ifndef __LEAKTRACER_MUTEX_h_included__
+#define __LEAKTRACER_MUTEX_h_included__
+
+#include <pthread.h>
+#include <stdio.h>
+
+#ifndef TRACE
+#ifdef LOGGER
+#define TRACE(arg) fprintf arg
+#else
+#define TRACE(arg)
+#endif
+#endif
+
+namespace leaktracer {
+
+// forward declaration
+class MutexLock;
+
+/**
+ * Wrapper to "pthread_mutex_t", should be used with
+ * <b>MutexLock</b> class, which insures that the mutex is
+ * released even in case of exception.
+ */
+class Mutex { // not intended to be overridden, non-virtual destructor
+public:
+	inline Mutex() {
+//		TRACE((stderr, "LeakTracer: Mutex()\n"));
+		pthread_mutexattr_t attr;
+		pthread_mutexattr_init(&attr);
+//		pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+		pthread_mutex_init(&__mutex, &attr);
+		pthread_mutexattr_destroy(&attr);
+	}
+
+	// not intended to be overridden, non-virtual destructor
+	inline ~Mutex() {
+//		TRACE((stderr, "LeakTracer: ~Mutex()\n"));
+		pthread_mutex_destroy(&__mutex);
+	}
+
+	pthread_mutex_t	__mutex;
+
+protected:
+	friend class MutexLock;
+};
+
+}  // end namespace
+
+
+#endif  // include once

--- a/src/libraries/leaktracer/MutexLock.hpp
+++ b/src/libraries/leaktracer/MutexLock.hpp
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////
+//
+// LeakTracer
+// Contribution to original project by Erwin S. Andreasen
+// site: http://www.andreasen.org/LeakTracer/
+//
+// Added by Michael Gopshtein, 2006
+// mgopshtein@gmail.com
+//
+// Any comments/suggestions are welcome
+//
+////////////////////////////////////////////////////////
+
+#ifndef __LEAKTRACER_MUTEX_LOCK_h_included__
+#define __LEAKTRACER_MUTEX_LOCK_h_included__
+
+#include "Mutex.hpp"
+
+#include <pthread.h>
+
+namespace leaktracer {
+
+/**
+ * Used to lock <b>Mutex</b>, ensures that the mutex
+ * is always released.
+ *
+ * Example:
+ *
+ * class MyClass {
+ * private:
+ *    Mutex my_mutex;
+ *
+ * public:
+ *    void doSomething(void) {
+ *       MutexLock lock(my_mutex);
+ *       // some code
+ *    }
+ *    // the Mutex is released automatically by
+ *    // destructor of MutexLock, even is exception
+ *    // is thrown inside the body of the function.
+ * };
+ */
+class MutexLock {
+public:
+	inline explicit MutexLock(Mutex& m) : __mutex(m), __locked(true) {
+		pthread_mutex_lock(&__mutex.__mutex);
+	}
+
+	inline void unlock() {
+		if (__locked) {
+			__locked = false;
+			pthread_mutex_unlock(&__mutex.__mutex);
+		}
+	}
+
+	// no one should be derived from this (non-virtual destructor)
+	inline ~MutexLock() {
+		unlock();
+	}
+
+protected:
+	Mutex& __mutex;
+	bool __locked;
+};
+
+
+}  // end namespace
+
+#endif  // include once

--- a/src/libraries/leaktracer/ObjectsPool.hpp
+++ b/src/libraries/leaktracer/ObjectsPool.hpp
@@ -1,0 +1,254 @@
+////////////////////////////////////////////////////////
+//
+// LeakTracer
+// Contribution to original project by Erwin S. Andreasen
+// site: http://www.andreasen.org/LeakTracer/
+//
+// Added by Michael Gopshtein, 2006
+// mgopshtein@gmail.com
+//
+// Any comments/suggestions are welcome
+//
+////////////////////////////////////////////////////////
+
+#ifndef __OBJECTS_POOL_h_included__
+#define __OBJECTS_POOL_h_included__
+
+//////////////////////////////////////////////////////////
+// Objects' pool implementation
+//
+// Concept taken from "Pool" class, C++ Boost:
+// http://www.boost.org/libs/pool/doc/concepts.html
+//////////////////////////////////////////////////////////
+
+
+#include "Mutex.hpp"
+#include "MutexLock.hpp"
+#include <cstdlib>
+
+/**
+ * dynamic call interfaces to memory allocation functions in libc.so
+ */
+extern void* (*lt_malloc)(size_t size);
+extern void  (*lt_free)(void* ptr);
+extern void* (*lt_realloc)(void *ptr, size_t size);
+extern void* (*lt_calloc)(size_t nmemb, size_t size);
+
+/*
+ * underlying allocation, de-allocation used within
+ * this tool
+ */
+#define LT_MALLOC  (*lt_malloc)
+#define LT_FREE    (*lt_free)
+#define LT_REALLOC (*lt_realloc)
+#define LT_CALLOC  (*lt_calloc)
+
+namespace leaktracer {
+
+
+/**
+ * This class used for allocation of chunks of elements
+ * of type E on the heap
+ */
+template <typename E, unsigned int NumOfElementsInChunk>
+class TDefaultChunkAllocator
+{
+public:
+	E * allocate()
+	{
+		return (E*) LT_MALLOC( NumOfElementsInChunk * sizeof(E) );
+	}
+
+	void release( E * p )
+	{
+		LT_FREE(p);
+	}
+};
+
+
+//---------------------------------
+// type for list element, which may be
+// a data used by the client, or a pointer
+// to next free cell, when the cell is free
+template<typename T>
+struct t_list_element
+{
+	union {
+		unsigned char data[sizeof(T)];
+		t_list_element * next_free_cell;
+	};
+};
+
+
+
+#define FREE_CELL_NONE		NULL
+
+template <typename T,
+	unsigned int NumOfElementsInChunk,
+	bool IsThreadSafe = true,
+	typename CHUNK_ALLOCATOR = TDefaultChunkAllocator< t_list_element<T>, NumOfElementsInChunk > >
+class TObjectsPool
+{
+public:
+
+	//---------------------------------
+	// Returns a pointer to free object
+	// NOTE: no constructor is executed
+	void * allocate();
+
+
+	//---------------------------------
+	// Releases object when unused
+	void release( void *p );
+
+
+	//---------------------------------
+	// constructor
+	TObjectsPool();
+
+
+	//---------------------------------
+	// statistics
+	unsigned long getNumOfObjects();
+	unsigned long getNumOfChunks();
+
+
+private:
+	// internal allocate/release functions
+	void * allocate_unlocked();
+	void release_unlocked( void *p );
+
+	//---------------------------------
+	// initializes the "list"
+	void initializeList( t_list_element<T> *pChunk );
+
+	// the memory allocator function
+	CHUNK_ALLOCATOR __allocator;
+
+	// pointer to the first free element
+	t_list_element<T> *__first_free_cell;
+
+	// statistics
+	unsigned long __num_of_objects;
+	unsigned long __num_of_chunks;
+
+	// synchnonization
+	Mutex __mutex;
+};
+
+
+
+//======================================================
+// Implementation
+//======================================================
+
+//---------------------------------
+// constructor
+template <typename T, unsigned int NumOfElementsInChunk, bool IsThreadSafe, typename CHUNK_ALLOCATOR>
+TObjectsPool<T, NumOfElementsInChunk, IsThreadSafe, CHUNK_ALLOCATOR>::TObjectsPool()
+: __first_free_cell( FREE_CELL_NONE ), __num_of_objects(0), __num_of_chunks(0)
+{
+# if 0
+	// allocate the first block
+	t_list_element<T> *pBlock = __allocator.allocate();
+	if( NULL != pBlock ) {
+		initializeList( pBlock );
+		__num_of_chunks ++;
+	}
+#endif
+}
+
+
+//---------------------------------
+// initializing linked list of free cells
+template <typename T, unsigned int NumOfElementsInChunk, bool IsThreadSafe, typename CHUNK_ALLOCATOR>
+void TObjectsPool<T, NumOfElementsInChunk, IsThreadSafe, CHUNK_ALLOCATOR>::initializeList( t_list_element<T> *pChunk )
+{
+	for( unsigned int i = 0; i < NumOfElementsInChunk; i++ )
+		pChunk[i].next_free_cell = pChunk + i + 1;
+
+	pChunk[NumOfElementsInChunk - 1].next_free_cell = __first_free_cell;
+	__first_free_cell = pChunk;
+}
+
+
+//---------------------------------
+// allocating objects
+template <typename T, unsigned int NumOfElementsInChunk, bool IsThreadSafe, typename CHUNK_ALLOCATOR>
+void * TObjectsPool<T, NumOfElementsInChunk, IsThreadSafe, CHUNK_ALLOCATOR>::allocate_unlocked()
+{
+	if( FREE_CELL_NONE == __first_free_cell )
+	{
+		// try to allocate additional block
+		t_list_element<T> *pNewBlock = __allocator.allocate();
+		if( NULL != pNewBlock ) {
+			initializeList( pNewBlock );
+			__num_of_chunks ++;
+		}
+
+		if( FREE_CELL_NONE == __first_free_cell )
+			return NULL;
+	}
+
+	void* retVal = static_cast<void*>( &(__first_free_cell->data) );
+	__first_free_cell = __first_free_cell->next_free_cell;
+	__num_of_objects ++;
+	return retVal;
+}
+
+template <typename T, unsigned int NumOfElementsInChunk, bool IsThreadSafe, typename CHUNK_ALLOCATOR>
+void * TObjectsPool<T, NumOfElementsInChunk, IsThreadSafe, CHUNK_ALLOCATOR>::allocate()
+{
+	if (! IsThreadSafe)
+		return allocate_unlocked();
+
+	MutexLock lock(__mutex);
+	return allocate_unlocked();
+}
+
+
+//---------------------------------
+// ideallocating objects
+template <typename T, unsigned int NumOfElementsInChunk, bool IsThreadSafe, typename CHUNK_ALLOCATOR>
+void TObjectsPool<T, NumOfElementsInChunk, IsThreadSafe, CHUNK_ALLOCATOR>::release_unlocked( void *p )
+{
+	t_list_element<T> *pReleased = reinterpret_cast<t_list_element<T> *>( p );
+	pReleased->next_free_cell = __first_free_cell;
+	__first_free_cell = pReleased;
+
+	if( __num_of_objects != 0 )
+		__num_of_objects --;
+}
+
+template <typename T, unsigned int NumOfElementsInChunk, bool IsThreadSafe, typename CHUNK_ALLOCATOR>
+void TObjectsPool<T, NumOfElementsInChunk, IsThreadSafe, CHUNK_ALLOCATOR>::release( void *p )
+{
+	if( p == NULL ) return;
+
+	if (! IsThreadSafe) {
+		release_unlocked(p);
+	} else {
+		MutexLock lock(__mutex);
+		release_unlocked(p);
+	}
+}
+
+
+// Statistics
+template <typename T, unsigned int NumOfElementsInChunk, bool IsThreadSafe, typename CHUNK_ALLOCATOR>
+unsigned long TObjectsPool<T, NumOfElementsInChunk, IsThreadSafe, CHUNK_ALLOCATOR>::getNumOfObjects()
+{
+	return __num_of_objects;
+}
+
+template <typename T, unsigned int NumOfElementsInChunk, bool IsThreadSafe, typename CHUNK_ALLOCATOR>
+unsigned long TObjectsPool<T, NumOfElementsInChunk, IsThreadSafe, CHUNK_ALLOCATOR>::getNumOfChunks()
+{
+	return __num_of_chunks;
+}
+
+
+}; // namespace
+
+
+#endif  // include once

--- a/src/libraries/leaktracer/leaktracer.h
+++ b/src/libraries/leaktracer/leaktracer.h
@@ -1,0 +1,31 @@
+#ifndef __LEAKTRACER_H__
+#define __LEAKTRACER_H__
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/** starts monitoring memory allocations in all threads */
+void leaktracer_startMonitoringAllThreads(void);
+
+/** starts monitoring memory allocations in current thread */
+void leaktracer_startMonitoringThisThread(void);
+
+/** stops monitoring memory allocations (in all threads or in
+ *   this thread only, depends on the function used to start
+ *   monitoring
+ */
+void leaktracer_stopMonitoringAllocations(void);
+
+/** stops all monitoring - both of allocations and releases */
+void leaktracer_stopAllMonitoring(void);
+
+/** writes report with all memory leaks */
+void leaktracer_writeLeaksToFile(const char* reportFileName);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LEAKTRACER_H */

--- a/src/libraries/leaktracer/src/AllocationHandlers.cpp
+++ b/src/libraries/leaktracer/src/AllocationHandlers.cpp
@@ -1,0 +1,124 @@
+////////////////////////////////////////////////////////
+//
+// LeakTracer
+// Contribution to original project by Erwin S. Andreasen
+// site: http://www.andreasen.org/LeakTracer/
+//
+// Added by Michael Gopshtein, 2006
+// mgopshtein@gmail.com
+//
+// Any comments/suggestions are welcome
+//
+////////////////////////////////////////////////////////
+
+#include "MemoryTrace.hpp"
+#include "LeakTracer_l.hpp"
+
+void* (*lt_malloc)(size_t size);
+void  (*lt_free)(void* ptr);
+void* (*lt_realloc)(void *ptr, size_t size);
+void* (*lt_calloc)(size_t nmemb, size_t size);
+
+void* operator new(size_t size) {
+	void *p;
+	leaktracer::MemoryTrace::Setup();
+
+	p = LT_MALLOC(size);
+	leaktracer::MemoryTrace::GetInstance().registerAllocation(p, size, false);
+
+	return p;
+}
+
+
+void* operator new[] (size_t size) {
+	void *p;
+	leaktracer::MemoryTrace::Setup();
+
+	p = LT_MALLOC(size);
+	leaktracer::MemoryTrace::GetInstance().registerAllocation(p, size, true);
+
+	return p;
+}
+
+
+void operator delete (void *p) {
+	leaktracer::MemoryTrace::Setup();
+
+	leaktracer::MemoryTrace::GetInstance().registerRelease(p, false);
+	LT_FREE(p);
+}
+
+
+void operator delete[] (void *p) {
+	leaktracer::MemoryTrace::Setup();
+
+	leaktracer::MemoryTrace::GetInstance().registerRelease(p, true);
+	LT_FREE(p);
+}
+
+/** -- libc memory operators -- **/
+
+/* malloc
+ * in some malloc implementation, there is a recursive call to malloc
+ * (for instance, in uClibc 0.9.29 malloc-standard )
+ * we use a InternalMonitoringDisablerThreadUp that use a tls variable to prevent several registration
+ * during the same malloc
+ */
+void *malloc(size_t size)
+{
+	void *p;
+	leaktracer::MemoryTrace::Setup();
+
+	leaktracer::MemoryTrace::GetInstance().InternalMonitoringDisablerThreadUp();
+	p = LT_MALLOC(size);
+	leaktracer::MemoryTrace::GetInstance().InternalMonitoringDisablerThreadDown();
+	leaktracer::MemoryTrace::GetInstance().registerAllocation(p, size, false);
+
+	return p;
+}
+
+void free(void* ptr)
+{
+	leaktracer::MemoryTrace::Setup();
+
+	leaktracer::MemoryTrace::GetInstance().registerRelease(ptr, false);
+	LT_FREE(ptr);
+}
+
+void* realloc(void *ptr, size_t size)
+{
+	void *p;
+	leaktracer::MemoryTrace::Setup();
+
+	leaktracer::MemoryTrace::GetInstance().InternalMonitoringDisablerThreadUp();
+
+	p = LT_REALLOC(ptr, size);
+
+	leaktracer::MemoryTrace::GetInstance().InternalMonitoringDisablerThreadDown();
+
+	if (p != ptr)
+	{
+		if (ptr)
+			leaktracer::MemoryTrace::GetInstance().registerRelease(ptr, false);
+		leaktracer::MemoryTrace::GetInstance().registerAllocation(p, size, false);
+	}
+	else
+	{
+		leaktracer::MemoryTrace::GetInstance().registerReallocation(p, size, false);
+	}
+
+	return p;
+}
+
+void* calloc(size_t nmemb, size_t size)
+{
+	void *p;
+	leaktracer::MemoryTrace::Setup();
+
+	leaktracer::MemoryTrace::GetInstance().InternalMonitoringDisablerThreadUp();
+	p = LT_CALLOC(nmemb, size);
+	leaktracer::MemoryTrace::GetInstance().InternalMonitoringDisablerThreadDown();
+	leaktracer::MemoryTrace::GetInstance().registerAllocation(p, nmemb*size, false);
+
+	return p;
+}

--- a/src/libraries/leaktracer/src/LeakTracerC.cpp
+++ b/src/libraries/leaktracer/src/LeakTracerC.cpp
@@ -1,0 +1,36 @@
+#include "leaktracer.h"
+#include "MemoryTrace.hpp"
+
+
+/** starts monitoring memory allocations in all threads */
+void leaktracer_startMonitoringAllThreads()
+{
+	leaktracer::MemoryTrace::GetInstance().startMonitoringAllThreads();
+}
+
+/** starts monitoring memory allocations in current thread */
+void leaktracer_startMonitoringThisThread()
+{
+	leaktracer::MemoryTrace::GetInstance().startMonitoringThisThread();
+}
+
+/** stops monitoring memory allocations (in all threads or in
+ *   this thread only, depends on the function used to start
+ *   monitoring
+ */
+void leaktracer_stopMonitoringAllocations()
+{
+	leaktracer::MemoryTrace::GetInstance().stopMonitoringAllocations();
+}
+
+/** stops all monitoring - both of allocations and releases */
+void leaktracer_stopAllMonitoring()
+{
+	leaktracer::MemoryTrace::GetInstance().stopAllMonitoring();
+}
+
+/** writes report with all memory leaks */
+void leaktracer_writeLeaksToFile(const char* reportFileName)
+{
+	leaktracer::MemoryTrace::GetInstance().writeLeaksToFile(reportFileName);
+}

--- a/src/libraries/leaktracer/src/MemoryTrace.cpp
+++ b/src/libraries/leaktracer/src/MemoryTrace.cpp
@@ -1,0 +1,384 @@
+////////////////////////////////////////////////////////
+//
+// LeakTracer
+// Contribution to original project by Erwin S. Andreasen
+// site: http://www.andreasen.org/LeakTracer/
+//
+// Added by Michael Gopshtein, 2006
+// mgopshtein@gmail.com
+//
+// Any comments/suggestions are welcome
+//
+////////////////////////////////////////////////////////
+
+#include <sys/syscall.h>
+
+#include "MemoryTrace.hpp"
+#include <ctype.h>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <string>
+
+#include <dlfcn.h>
+#include <assert.h>
+#include <unistd.h>
+
+
+#include <stdio.h>
+#include "LeakTracer_l.hpp"
+
+// glibc/eglibc: dlsym uses calloc internally now, so use weak symbol to get their symbol
+extern "C" void* __libc_malloc(size_t size) __attribute__((weak));
+extern "C" void  __libc_free(void* ptr) __attribute__((weak));
+extern "C" void* __libc_realloc(void *ptr, size_t size) __attribute__((weak));
+extern "C" void* __libc_calloc(size_t nmemb, size_t size) __attribute__((weak));
+
+namespace leaktracer {
+
+typedef struct {
+  const char *symbname;
+  void *libcsymbol;
+  void **localredirect;
+} libc_alloc_func_t;
+
+static libc_alloc_func_t libc_alloc_funcs[] = {
+  { "calloc", (void*)__libc_calloc, (void**)(&lt_calloc) },
+  { "malloc", (void*)__libc_malloc, (void**)(&lt_malloc) },
+  { "realloc", (void*)__libc_realloc, (void**)(&lt_realloc) },
+  { "free", (void*)__libc_free, (void**)(&lt_free) }
+};
+
+MemoryTrace *MemoryTrace::__instance = NULL;
+char s_memoryTrace_instance[sizeof(MemoryTrace)];
+pthread_once_t MemoryTrace::_init_no_alloc_allowed_once = PTHREAD_ONCE_INIT;
+pthread_once_t MemoryTrace::_init_full_once = PTHREAD_ONCE_INIT;
+
+int MemoryTrace::__sigStartAllThread = 0;
+int MemoryTrace::__sigStopAllThread = 0;
+int MemoryTrace::__sigReport = 0;
+
+
+MemoryTrace::MemoryTrace(void) :
+	__setupDone(false), __monitoringAllThreads(false), __monitoringReleases(false), __monitoringDisabler(0)
+{
+}
+
+void MemoryTrace::sigactionHandler(int sigNumber, siginfo_t *siginfo, void *arg)
+{
+	(void)siginfo;
+	(void)arg;
+	if (sigNumber == __sigStartAllThread)
+	{
+		TRACE((stderr, "MemoryTracer: signal %d received, starting monitoring\n", sigNumber));
+		leaktracer::MemoryTrace::GetInstance().startMonitoringAllThreads();
+	}
+	if (sigNumber == __sigStopAllThread)
+	{
+  		TRACE((stderr, "MemoryTracer: signal %d received, stoping monitoring\n", sigNumber));
+		leaktracer::MemoryTrace::GetInstance().stopAllMonitoring();
+	}
+	if (sigNumber == __sigReport)
+	{
+		const char* reportFilename;
+		if (getenv("LEAKTRACER_ONSIG_REPORTFILENAME") == NULL)
+			reportFilename = "leaks.out";
+		else
+			reportFilename = getenv("LEAKTRACER_ONSIG_REPORTFILENAME");
+		TRACE((stderr, "MemoryTracer: signal %d received, writing report to %s\n", sigNumber, reportFilename));
+		leaktracer::MemoryTrace::GetInstance().writeLeaksToFile(reportFilename);
+	}
+}
+
+int MemoryTrace::signalNumberFromString(const char* signame)
+{
+	if (strncmp(signame, "SIG", 3) == 0)
+		signame += 3;
+
+	if (strcmp(signame, "USR1") == 0)
+		return SIGUSR1;
+	else if (strcmp(signame, "USR2") == 0)
+		return SIGUSR2;
+	else
+		return atoi(signame);
+}
+
+void
+MemoryTrace::init_no_alloc_allowed()
+{
+	libc_alloc_func_t *curfunc;
+	unsigned i;
+
+ 	for (i=0; i<(sizeof(libc_alloc_funcs)/sizeof(libc_alloc_funcs[0])); ++i) {
+		curfunc = &libc_alloc_funcs[i];
+		if (!*curfunc->localredirect) {
+			if (curfunc->libcsymbol) {
+				*curfunc->localredirect = curfunc->libcsymbol;
+			} else {
+				*curfunc->localredirect = dlsym(RTLD_NEXT, curfunc->symbname); 
+			}
+		}
+	} 
+
+	__instance = reinterpret_cast<MemoryTrace*>(&s_memoryTrace_instance);
+
+	// we're using a c++ placement to initialized the MemoryTrace object living in the data section
+	new (__instance) MemoryTrace();
+
+	// it seems some implementation of pthread_key_create use malloc() internally (old linuxthreads)
+	// these are not supported yet
+	pthread_key_create(&__instance->__thread_internal_disabler_key, NULL);
+}
+
+void
+MemoryTrace::init_full_from_once()
+{
+	leaktracer::MemoryTrace::GetInstance().init_full();
+}
+
+void
+MemoryTrace::init_full()
+{
+	int sigNumber;
+	struct sigaction sigact;
+
+	__monitoringDisabler++;
+
+	void *testmallocok = malloc(1);
+	free(testmallocok);
+
+	pthread_key_create(&__thread_options_key, CleanUpThreadData);
+
+	if (!getenv("LEAKTRACER_NOBANNER"))
+	{
+#ifdef SHARED
+		fprintf(stderr, "LeakTracer " LEAKTRACER_VERSION " (shared library) -- LGPLv2\n");
+#else
+		fprintf(stderr, "LeakTracer " LEAKTRACER_VERSION " (static library) -- LGPLv2\n");
+#endif
+	}
+
+	if (getenv("LEAKTRACER_ONSIG_STARTALLTHREAD"))
+	{
+		sigact.sa_sigaction = sigactionHandler;
+		sigemptyset(&sigact.sa_mask);
+		sigact.sa_flags = SA_SIGINFO;
+		sigNumber = signalNumberFromString(getenv("LEAKTRACER_ONSIG_STARTALLTHREAD"));
+		__sigStartAllThread = sigNumber;
+		sigaction(sigNumber, &sigact, NULL);
+		TRACE((stderr, "LeakTracer: registered signal %d SIGSTART for tid %d\n", sigNumber, (pid_t) syscall (SYS_gettid)));
+	}
+
+	if (getenv("LEAKTRACER_ONSIG_STOPALLTHREAD"))
+	{
+		sigact.sa_sigaction = sigactionHandler;
+		sigemptyset(&sigact.sa_mask);
+		sigact.sa_flags = SA_SIGINFO;
+		sigNumber = signalNumberFromString(getenv("LEAKTRACER_ONSIG_STOPALLTHREAD"));
+		__sigStopAllThread = sigNumber;
+		sigaction(sigNumber, &sigact, NULL);
+		TRACE((stderr, "LeakTracer: registered signal %d SIGSTOP for tid %d\n", sigNumber, (pid_t) syscall (SYS_gettid)));
+	}
+
+	if (getenv("LEAKTRACER_ONSIG_REPORT"))
+	{
+		sigact.sa_sigaction = sigactionHandler;
+		sigemptyset(&sigact.sa_mask);
+		sigact.sa_flags = SA_SIGINFO;
+		sigNumber = signalNumberFromString(getenv("LEAKTRACER_ONSIG_REPORT"));
+		__sigReport = sigNumber;
+		sigaction(sigNumber, &sigact, NULL);
+		TRACE((stderr, "LeakTracer: registered signal %d SIGREPORT for tid %d\n", sigNumber, (pid_t) syscall (SYS_gettid)));
+	}
+
+	if (getenv("LEAKTRACER_ONSTART_STARTALLTHREAD") || getenv("LEAKTRACER_AUTO_REPORTFILENAME"))
+	{
+		leaktracer::MemoryTrace::GetInstance().startMonitoringAllThreads();
+	}
+#ifdef USE_BACKTRACE
+	// we call backtrace here, because there is some init on its first call
+	void *bt;
+	backtrace(&bt, 1);
+#endif
+	__setupDone = true;
+
+	__monitoringDisabler--;
+}
+
+int MemoryTrace::Setup(void)
+{
+	pthread_once(&MemoryTrace::_init_no_alloc_allowed_once, MemoryTrace::init_no_alloc_allowed);
+
+	if (!leaktracer::MemoryTrace::GetInstance().AllMonitoringIsDisabled()) {
+		pthread_once(&MemoryTrace::_init_full_once, MemoryTrace::init_full_from_once);
+	}
+#if 0
+        else if (!leaktracer::MemoryTrace::GetInstance().__setupDone) {
+	}	
+#endif
+	return 0;
+}
+
+void MemoryTrace::MemoryTraceOnInit(void)
+{
+	//TRACE((stderr, "LeakTracer: MemoryTrace::MemoryTraceOnInit\n"));
+	leaktracer::MemoryTrace::Setup();
+}
+
+
+void MemoryTrace::MemoryTraceOnExit(void)
+{
+	if (getenv("LEAKTRACER_ONEXIT_REPORT") || getenv("LEAKTRACER_AUTO_REPORTFILENAME"))
+	{
+		const char *reportName;
+		if ( !(reportName = getenv("LEAKTRACER_ONEXIT_REPORTFILENAME")) && !(reportName = getenv("LEAKTRACER_AUTO_REPORTFILENAME")))
+		{
+			TRACE((stderr, "LeakTracer: LEAKTRACER_ONEXIT_REPORTFILENAME needs to be defined when using LEAKTRACER_ONEXIT_REPORT\n"));
+			return;
+		}
+		leaktracer::MemoryTrace::GetInstance().stopAllMonitoring();
+		TRACE((stderr, "LeakTracer: writing leak report in %s\n", reportName));
+		leaktracer::MemoryTrace::GetInstance().writeLeaksToFile(reportName);
+	}
+	
+	const char *exitCode = getenv("LEAKTRACER_EXIT_CODE_ON_LEAKS");
+	if (exitCode != NULL && !leaktracer::MemoryTrace::GetInstance().__allocations.empty())
+	{
+		exit(atoi(exitCode));
+	}
+}
+
+MemoryTrace::~MemoryTrace(void)
+{
+	pthread_key_delete(__thread_options_key);
+}
+
+
+
+// is called automatically when thread exists, whould
+// cleanup per-thread data
+void MemoryTrace::CleanUpThreadData(void *ptrThreadOptions)
+{
+	if( ptrThreadOptions != NULL )
+		GetInstance().removeThreadOptions( reinterpret_cast<ThreadMonitoringOptions*>(ptrThreadOptions) );
+}
+
+
+// cleans per-thread configuration object, and removes
+// it from the list of all objects
+void MemoryTrace::removeThreadOptions(ThreadMonitoringOptions *pOptions)
+{
+	MutexLock lock(__threadListMutex);
+	for (list_monitoring_options_t::iterator it = __listThreadOptions.begin(); it != __listThreadOptions.end(); ++it) {
+		if (*it == pOptions) {
+			// found this object in the list
+			delete *it;
+			__listThreadOptions.erase(it);
+			return;
+		}
+	}
+}
+
+
+// writes all memory leaks to given stream
+void MemoryTrace::writeLeaksPrivate(std::ostream &out)
+{
+	struct timespec mono, utc, diff;
+	allocation_info_t *info;
+	void *p;
+	double d;
+	const int precision = 6;
+	int maxsecwidth;
+
+	clock_gettime(CLOCK_REALTIME, &utc);
+	clock_gettime(CLOCK_MONOTONIC, &mono);
+
+	if (utc.tv_nsec > mono.tv_nsec) {
+		diff.tv_nsec = utc.tv_nsec - mono.tv_nsec;
+		diff.tv_sec = utc.tv_sec - mono.tv_sec;
+	} else {
+		diff.tv_nsec = 1000000000 - (mono.tv_nsec - utc.tv_nsec);
+		diff.tv_sec = utc.tv_sec - mono.tv_sec -1;
+	}
+
+	maxsecwidth = 0;
+	while(mono.tv_sec > 0) {
+		mono.tv_sec = mono.tv_sec/10;
+		maxsecwidth++;
+	}
+	if (maxsecwidth == 0) maxsecwidth=1;
+
+	out << "# LeakTracer report";
+	d = diff.tv_sec + (((double)diff.tv_nsec)/1000000000);
+	out << " diff_utc_mono=" << std::fixed << std::left << std::setprecision(precision) << d ;
+	out << "\n";
+
+	__allocations.beginIteration();
+	while (__allocations.getNextPair(&info, &p)) {
+		d = info->timestamp.tv_sec + (((double)info->timestamp.tv_nsec)/1000000000);
+		out << "leak, ";
+		out << "time="  << std::fixed << std::right << std::setprecision(precision) << std::setfill('0') << std::setw(maxsecwidth+1+precision) << d << ", "; // setw(16) ?
+		out << "stack=";
+		for (unsigned int i = 0; i < ALLOCATION_STACK_DEPTH; i++) {
+			if (info->allocStack[i] == NULL) break;
+
+			if (i > 0) out << ' ';
+			out << info->allocStack[i];
+		}
+		out << ", ";
+
+		out << "size=" << info->size << ", ";
+
+		out << "data=";
+		const char *data = reinterpret_cast<const char *>(p);
+		for (unsigned int i = 0; i < PRINTED_DATA_BUFFER_SIZE && i < info->size; i++)
+			out << (isprint(data[i]) ? data[i] : '.');
+		out << '\n';
+	}
+}
+
+
+// writes all memory leaks to given stream
+void MemoryTrace::writeLeaks(std::ostream &out)
+{
+	MutexLock lock(__allocations_mutex);
+	InternalMonitoringDisablerThreadUp();
+
+	writeLeaksPrivate(out);
+
+	InternalMonitoringDisablerThreadDown();
+}
+
+
+// writes all memory leaks to given stream
+void MemoryTrace::writeLeaksToFile(const char* reportFilename)
+{
+	if (__allocations.empty()) {
+		return; //no memory leak, not need to create leak file
+	}
+
+	MutexLock lock(__allocations_mutex);
+	InternalMonitoringDisablerThreadUp();
+
+	std::ofstream oleaks;
+	oleaks.open(reportFilename, std::ios_base::out);
+	if (oleaks.is_open())
+	{
+		writeLeaksPrivate(oleaks);
+		oleaks.close();
+	}
+	else
+	{
+		std::cerr << "Failed to write to \"" << reportFilename << "\"\n";
+	}
+	InternalMonitoringDisablerThreadDown();
+}
+
+void MemoryTrace::clearAllocationsInfo(void)
+{
+	MutexLock lock(__allocations_mutex);
+	__allocations.clearAllInfo();
+}
+
+
+}  // end namespace

--- a/src/libraries/leaktracer/tools/leak-analyze-addr2line
+++ b/src/libraries/leaktracer/tools/leak-analyze-addr2line
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+use IO::Handle;
+
+my $exe_name = shift (@ARGV);
+my $log_name = shift (@ARGV);
+
+if (!$exe_name || !$log_name) {
+   print "Usage: $0 <PROGRAM> <LEAKFILE>\n";
+   exit (1);
+}
+
+print "Processing \"$log_name\" log for \"$exe_name\"\n";
+
+print "Matching addresses to \"$exe_name\"\n";
+
+my %stacks;
+my %addresses;
+my $lines = 0;
+
+open (LEAKFILE, $log_name) || die("failed to read from \"$log_name\"");
+
+while (<LEAKFILE>) {
+   chomp;
+   my $line = $_;
+   if ($line =~ /^leak, time=([\d.]*), stack=([\w ]*), size=(\d*), data=.*/) {
+      $lines ++;
+
+      my $id = $2;
+      $stacks{$id}{COUNTER} ++;
+      $stacks{$id}{TIME} = $1;
+      $stacks{$id}{SIZE} += $3;
+
+      my @ptrs = split(/ /, $id);
+      foreach $ptr (@ptrs) {
+         $addresses{$ptr} = "unknown";
+      }
+   }
+}
+close (LEAKFILE);
+printf "found $lines leak(s)\n";
+if ($lines == 0) { exit 0; }
+
+# resolving addresses
+my @unique_addresses = keys (%addresses);
+my $addr_list = "";
+foreach $addr (@unique_addresses) { $addr_list .= " $addr"; }
+
+if (!open(ADDRLIST, "addr2line -e $exe_name $addr_list |")) { die "Failed to resolve addresses"; }
+my $addr_idx = 0;
+while (<ADDRLIST>) {
+   chomp;
+   $addresses{$unique_addresses[$addr_idx]} = $_;
+   $addr_idx++;
+}
+close (ADDRLIST);
+
+# printing allocations
+while (($stack, $info) = each(%stacks)) {
+   print $info->{SIZE}." bytes lost in ".$info->{COUNTER}." blocks (one of them allocated at ".$info->{TIME}."), from following call stack:\n";
+   @stack = split(/ /, $stack);
+   foreach $addr (@stack) { print "\t".$addresses{$addr}."\n"; }
+}

--- a/src/libraries/leaktracer/tools/leak-analyze-gdb
+++ b/src/libraries/leaktracer/tools/leak-analyze-gdb
@@ -1,0 +1,95 @@
+#!/usr/bin/perl
+use IO::Handle;
+
+my $exe_name = shift (@ARGV);
+my $log_name = shift (@ARGV);
+my $breakpoint;
+
+if ($#ARGV >= 0) {
+   $breakpoint = shift @ARGV;
+}
+
+if (!$exe_name || !$log_name) {
+   print "Usage: $0 <PROGRAM|PID> <LEAKTRACER LEAKFILE> [BREAKPOINT]\n";
+   exit (1);
+}
+
+my %stacks;
+my %addresses;
+my $lines = 0;
+
+open (LEAKFILE, $log_name) || die("failed to read from \"$log_name\"");
+
+while (<LEAKFILE>) {
+   chomp;
+   my $line = $_;
+   if ($line =~ /^leak, time=([\d.]*), stack=([\w ]*), size=(\d*), data=.*/) {
+      $lines ++;
+
+      my $id = $2;
+      $stacks{$id}{COUNTER} ++;
+      $stacks{$id}{TIME} = $1;
+      $stacks{$id}{SIZE} += $3;
+
+      my @ptrs = split(/ /, $id);
+      foreach $ptr (@ptrs) {
+         $addresses{$ptr} = "unknown";
+      }
+   }
+}
+close (LEAKFILE);
+printf "found $lines leak(s)\n";
+
+
+# Instead of using -batch, we just run things as usual. with -batch,
+# we quit on the first error, which we don't want.
+open (PIPE, "|gdb -q") or die "Cannot start gdb";
+#open (PIPE, "|cat");
+
+# Change set listsize 2 to something else to show more lines
+print PIPE "set prompt\nset complaints 1000\nset height 0\n";
+
+if ($exe_name eq int($exe_name)) {
+    print PIPE "attach $exe_name\n";
+}
+else
+{
+    print PIPE "file $exe_name\n";
+}
+
+print PIPE "set environment LD_PRELOAD /usr/lib/libleaktracer.so\n";
+
+# Optionally, run the program
+if (defined($breakpoint)) {
+    print PIPE "break $breakpoint\n";
+    print PIPE "run ", join(" ", @ARGV), " \n";
+}
+
+# printing allocations
+print PIPE "set listsize 1\n";
+print PIPE "set print symbol-filename on\n";
+
+#print PIPE "info sharedlibrary\n";
+
+while (($stack, $info) = each(%stacks)) {
+   print PIPE "echo ".$info->{SIZE}." bytes lost in ".$info->{COUNTER}." blocks (one of them allocated at ".$info->{TIME}."), from following call stack:\\n\n";
+   @stack = split(/ /, $stack);
+   foreach $addr (@stack) {
+    print PIPE "info symbol " . ($addr) . "\n";
+    print PIPE "l *" . ($addr) . "\n";
+   }
+    print PIPE "echo \\n\n";
+}
+
+if ($exe_name eq int($exe_name)) {
+    print PIPE "detach\n";
+}
+elsif (defined($breakpoint)) {
+    print PIPE "kill\n";
+}
+
+print PIPE "quit\n";
+PIPE->flush();
+wait();
+
+close (PIPE);

--- a/src/libraries/leaktracer/tools/leak-check
+++ b/src/libraries/leaktracer/tools/leak-check
@@ -1,0 +1,85 @@
+#!/bin/sh
+#
+# This is a helper for running custom executable with LeakTracer.
+#
+# Set LEAKTRACER_SHARED_LIB environment variable to specify a path to the LeakTracer library.
+#
+# Set LEAKTRACER_ONSIG environment variable to use signals for managing LeakTracer,
+# otherwise LeakTracer would be enabled from the start.
+#
+# You can override defaults by setting
+# - LEAKTRACER_ONSIG_REPORTFILENAME,
+# - LEAKTRACER_ONSIG_STARTALLTHREAD,
+# - LEAKTRACER_ONSIG_STOPALLTHREAD,
+# - LEAKTRACER_ONSIG_REPORT,
+# when LEAKTRACER_ONSIG is set, and
+# - LEAKTRACER_AUTO_REPORTFILENAME
+# otherwise.
+#
+# Copyright Nikita Melnichenko [http://nikita.melnichenko.name], 2012
+# Lisence: GPL v2
+
+
+
+# print usage
+if [ -z "$1" ] ; then
+	echo "Usage: $0 PROGRAM [PARAMETER]..."
+	exit 0
+fi
+
+# if library wasn't set explicitly, try the one in the current dir
+if [ -z "$LEAKTRACER_SHARED_LIB" ] && [ -x "./libleaktracer.so" ] ; then
+	LEAKTRACER_SHARED_LIB="./libleaktracer.so"
+fi
+
+# set a path to the LeakTracer library
+if [ -z "$LEAKTRACER_SHARED_LIB" ] ; then
+	# THIS SHOULD POINT TO THE SYSTEM LIBRARY:
+	# USE: sed -i -e 's|\tLEAKTRACER_SYSTEM_SHARED_LIB=.*|\tLEAKTRACER_SYSTEM_SHARED_LIB=/PATH/TO/LIB|' leak-check
+	LEAKTRACER_SYSTEM_SHARED_LIB=/usr/lib/libleaktracer.so
+	LEAKTRACER_SHARED_LIB="$LEAKTRACER_SYSTEM_SHARED_LIB"
+fi
+
+# check the library
+if ! [ -x "$LEAKTRACER_SHARED_LIB" ]
+then
+	echo "LeakTracer library '$LEAKTRACER_SHARED_LIB' not found!"
+	echo "Please, set a proper path in the LEAKTRACER_SHARED_LIB variable."
+	exit 1
+fi
+
+# set defaults for those variables that haven't been specified
+if ! [ -z "$LEAKTRACER_ONSIG" ] ; then
+
+	if [ -z "$LEAKTRACER_ONSIG_REPORTFILENAME" ] ; then
+		LEAKTRACER_ONSIG_REPORTFILENAME=leak.out
+	fi
+	if [ -z "$LEAKTRACER_ONSIG_STARTALLTHREAD" ] ; then
+		LEAKTRACER_ONSIG_STARTALLTHREAD=USR1
+	fi
+	if [ -z "$LEAKTRACER_ONSIG_REPORT" ] ; then
+		LEAKTRACER_ONSIG_REPORT=USR2
+	fi
+
+	export LEAKTRACER_ONSIG_REPORTFILENAME
+	export LEAKTRACER_ONSIG_STARTALLTHREAD
+	export LEAKTRACER_ONSIG_REPORT
+
+	REPORTFILENAME="$LEAKTRACER_ONSIG_REPORTFILENAME"
+
+elif [ -z "$LEAKTRACER_AUTO_REPORTFILENAME" ] ; then
+
+	export LEAKTRACER_AUTO_REPORTFILENAME=leak.out
+
+	REPORTFILENAME="$LEAKTRACER_AUTO_REPORTFILENAME"
+
+fi
+
+# save old report file
+if [ -f "$REPORTFILENAME" ] ; then
+	mv "$REPORTFILENAME" "$REPORTFILENAME-`stat --format '%Y' "$REPORTFILENAME"`"
+fi
+
+# run the program
+export LD_PRELOAD="$LEAKTRACER_SHARED_LIB"
+exec $@

--- a/src/libraries/xchaininit/CMakeLists.txt
+++ b/src/libraries/xchaininit/CMakeLists.txt
@@ -55,3 +55,7 @@ target_link_libraries(xchaininit PRIVATE ${LINK_ARGS}
     xxbase
     jsoncpp
     -lpthread -ldl)
+
+if (LEAK_TRACER)
+    target_link_libraries(xchaininit PRIVATE leaktracer)
+endif()


### PR DESCRIPTION
#### leak_tracer:
http://www.andreasen.org/LeakTracer/

#### how to use:
1. build xtopchain with leak_tracer option:   `./build.sh leak_tracer`
2. run xtopchain
3. kill -10 xtopchain_PID (send a signal to print all memory alloc) might like this `ps -ef |grep xtopchain |grep zec1 |awk -F ' ' '{print $2}'|xargs kill -10`
4. use tools to analyse the file generated by last step `./leak-analyze-addr2line xtopchain T00000LXqp1NkfooMAw7Bty2iXTxgTCfsygMnxrT1621325580263447995leaks.out > zec1.out`

