### PR TITLE
feat(tools): add gperf tools && build_option

### DIFF
--- a/src/libraries/xchaininit/CMakeLists.txt
+++ b/src/libraries/xchaininit/CMakeLists.txt
@@ -59,3 +59,7 @@ target_link_libraries(xchaininit PRIVATE ${LINK_ARGS}
 if (LEAK_TRACER)
     target_link_libraries(xchaininit PRIVATE leaktracer)
 endif()
+
+if (BUILD_GPERF)
+    target_link_libraries(xchaininit PRIVATE profiler)
+endif()


### PR DESCRIPTION
### gperf:
https://gperftools.github.io/gperftools/cpuprofile.html
### how to use:
1. build with gperf:  `./build.sh gperf [release]` 
2. send user signal : `kill -s 12 PID` to start
3. wait for few minutes and send signal again : `kill -s 12 PID` to stop ,which will generate xxx.prof
4. use `pprof` tools to analyse `.prof` file:
    - `pprof xtopchain xxx.prof --text > res.txt`
    - `pprof xtopchain xxx.prof [--focus={re} , --nodecount=180 , --ignore={re} ] --pdf > res.pdf`