### PR TITLE
bug(blockstore): if connect_block type is full, latest_committed_full…

### DIFF
--- a/src/xtopcom/xblockstore/src/xvunithub.cpp
+++ b/src/xtopcom/xblockstore/src/xvunithub.cpp
@@ -226,6 +226,10 @@ namespace top
             if(connect_block != nullptr)
             {
                 auto latest_committed_full_height = connect_block->get_last_full_block_height();
+                if(connect_block->get_block_class() == base::enum_xvblock_class_full)
+                {
+                    latest_committed_full_height = connect_block->get_height();
+                }
                 return load_block_object(account, latest_committed_full_height, 0, true);
             }
 


### PR DESCRIPTION
…_height should be the height of connect block