### PR TITLE
perf(p2p): delete root_routing_manager map

### DIFF
--- a/src/xtopcom/xelect_net/include/multilayer_network.h
+++ b/src/xtopcom/xelect_net/include/multilayer_network.h
@@ -62,7 +62,6 @@ private:
     void RegisterCallbackForMultiThreadHandler(
             std::shared_ptr<top::transport::MultiThreadHandler> multi_thread_message_handler);
     std::shared_ptr<top::wrouter::RootRoutingManager> CreateRootManager(
-            bool client,
             std::shared_ptr<transport::Transport> transport,
             const top::base::Config& config,
             const std::set<std::pair<std::string, uint16_t>>& public_endpoints_config);

--- a/src/xtopcom/xelect_net/src/multilayer_network.cc
+++ b/src/xtopcom/xelect_net/src/multilayer_network.cc
@@ -321,7 +321,6 @@ void MultilayerNetwork::RegisterCallbackForMultiThreadHandler(
 }
 
 std::shared_ptr<top::wrouter::RootRoutingManager> MultilayerNetwork::CreateRootManager(
-        bool client,
         std::shared_ptr<transport::Transport> transport,
         const top::base::Config& config,
         const std::set<std::pair<std::string, uint16_t>>& public_endpoints_config) {
@@ -332,12 +331,6 @@ std::shared_ptr<top::wrouter::RootRoutingManager> MultilayerNetwork::CreateRootM
         return nullptr;
     }
 
-    if (client) {
-        if (!new_config.Set("node", "client_mode", true)) {
-            TOP_ERROR("set config node client_mode failed!");
-            return nullptr;
-        }
-    }
     auto root_manager_ptr = wrouter::RootRoutingManager::Instance();
     wrouter::MultiRouting::Instance()->SetRootRoutingManager(root_manager_ptr);
 
@@ -360,12 +353,7 @@ std::shared_ptr<top::wrouter::RootRoutingManager> MultilayerNetwork::CreateRootM
 
     auto get_cache_callback = std::bind(&MultilayerNetwork::GetBootstrapCacheCallback, this, std::placeholders::_1, std::placeholders::_2);
     auto set_cache_callback = std::bind(&MultilayerNetwork::SetBootstrapCacheCallback, this, std::placeholders::_1, std::placeholders::_2);
-    if (root_manager_ptr->AddRoutingTable(
-            transport,
-            new_config,
-            kad_key_ptr,
-            get_cache_callback,
-            set_cache_callback) != top::kadmlia::kKadSuccess) {
+    if (root_manager_ptr->InitRootRoutingTable(transport, new_config, kad_key_ptr, get_cache_callback, set_cache_callback) != top::kadmlia::kKadSuccess) {
         TOP_ERROR("<blueshi> add root_table[root] failed!");
         return nullptr;
     }
@@ -382,7 +370,6 @@ int MultilayerNetwork::ResetRootRouting(
     kadmlia::GetPublicEndpointsConfig(config, public_endpoints_config);
 
     root_manager_ptr_ = CreateRootManager(
-            false,
             transport,
             config,
             public_endpoints_config);

--- a/src/xtopcom/xwrouter/multi_routing/multi_routing.h
+++ b/src/xtopcom/xwrouter/multi_routing/multi_routing.h
@@ -29,7 +29,6 @@ public:
     void AddRoutingTable(uint64_t type, kadmlia::RoutingTablePtr routing_table);
     void RemoveRoutingTable(uint64_t type);
 
-
     void SetRootRoutingManager(std::shared_ptr<RootRoutingManager> root_manager_ptr);
 
 private:
@@ -44,9 +43,6 @@ private:
         uint64_t service_type,
         std::set<std::pair<std::string, uint16_t>>& boot_endpoints);
     friend bool SetCacheServiceType(uint64_t service_type);
-    
-    
-    void RemoveAllRoutingTable();
     
     void GetAllRegisterType(std::vector<uint64_t>& vec_type);
     void GetAllRegisterRoutingTable(std::vector<std::shared_ptr<kadmlia::RoutingTable>>& vec_rt);

--- a/src/xtopcom/xwrouter/multi_routing/service_node_cache.h
+++ b/src/xtopcom/xwrouter/multi_routing/service_node_cache.h
@@ -30,12 +30,10 @@ public:
 
     // search service_type nodes from bootstrap network
     bool GetRootNodes(uint64_t service_type, std::vector<kadmlia::NodeInfoPtr> & node_vec);
-    bool GetRootNodes(uint64_t service_type, const std::string & account, std::vector<kadmlia::NodeInfoPtr> & node_vec);
     // for point2point, get des_node_id if exist, or get same service_type node
     bool GetRootNodes(uint64_t service_type, const std::string & des_node_id, kadmlia::NodeInfoPtr & node_ptr);
 
     bool FindNode(uint64_t service_type, std::vector<kadmlia::NodeInfoPtr> & node_vec);
-    bool FindNode(uint64_t service_type, kadmlia::NodeInfoPtr & node_ptr);
     bool FindNode(uint64_t service_type, const std::string & des_node_id, kadmlia::NodeInfoPtr & node_ptr);
     bool CheckHasNode(base::KadmliaKeyPtr kad_key);
     void RemoveExpired(const std::unordered_map<uint64_t, std::vector<std::string>> & expired_node_vec);

--- a/src/xtopcom/xwrouter/root/root_routing_manager.h
+++ b/src/xtopcom/xwrouter/root/root_routing_manager.h
@@ -34,21 +34,15 @@ public:
     static RootRoutingManagerPtr Instance();
     RootRoutingManager();
     ~RootRoutingManager();
-    int AddRoutingTable(
-            std::shared_ptr<transport::Transport> transport,
-            const base::Config& config,
-            base::KadmliaKeyPtr kad_key_ptr,
-            on_bootstrap_cache_get_callback_t get_cache_callback,
-            on_bootstrap_cache_set_callback_t set_cache_callback,
-            bool wait_for_joined = true);
-    void RemoveRoutingTable(uint64_t service_type);
-    void RemoveAllRoutingTable();
+    void Destory();
+    int InitRootRoutingTable(std::shared_ptr<transport::Transport> transport,
+                             const base::Config & config,
+                             base::KadmliaKeyPtr kad_key_ptr,
+                             on_bootstrap_cache_get_callback_t get_cache_callback,
+                             on_bootstrap_cache_set_callback_t set_cache_callback,
+                             bool wait_for_joined = true);
     std::shared_ptr<kadmlia::RoutingTable> GetRoutingTable(uint64_t service_type);
-    std::shared_ptr<kadmlia::RoutingTable> GetRoutingTable(const std::string& routing_id);
     int GetRootNodes(uint32_t network_id, std::vector<kadmlia::NodeInfoPtr>& root_nodes);
-    int GetRootNodes(
-            const std::string& des_id,
-            std::vector<kadmlia::NodeInfoPtr>& root_nodes);
     int GetRootNodesV2(
             const std::string& des_id,
             uint64_t service_type,
@@ -84,9 +78,8 @@ private:
             uint64_t service_type,
             const std::vector<kadmlia::NodeInfoPtr>& nodes);
 
-private:
-    std::map<uint64_t, std::shared_ptr<kadmlia::RoutingTable>> root_routing_map_;
-    std::mutex root_routing_map_mutex_;
+	std::shared_ptr<kadmlia::RoutingTable> root_routing_table_;
+    std::mutex root_routing_table_mutex_;
 
     DISALLOW_COPY_AND_ASSIGN(RootRoutingManager);
 };

--- a/src/xtopcom/xwrouter/src/multi_routing.cc
+++ b/src/xtopcom/xwrouter/src/multi_routing.cc
@@ -66,8 +66,8 @@ void MultiRouting::AddRoutingTable(uint64_t type, RoutingTablePtr routing_table)
 }
 
 void MultiRouting::RemoveRoutingTable(uint64_t type) {
-    if (root_manager_ptr_) {
-        root_manager_ptr_->RemoveRoutingTable(type);
+    if (type == kRoot && root_manager_ptr_) {
+        root_manager_ptr_->Destory();
         TOP_KINFO("remove root routing table: %llu", type);
     }
 
@@ -92,25 +92,6 @@ void MultiRouting::RemoveRoutingTable(uint64_t type) {
     }
 }
 
-void MultiRouting::RemoveAllRoutingTable() {
-    if (root_manager_ptr_) {
-        root_manager_ptr_->RemoveAllRoutingTable();
-        TOP_KINFO("remove all root routing table");
-    }
-
-    decltype(routing_table_map_) rt_map;
-    {
-        std::unique_lock<std::mutex> lock(routing_table_map_mutex_);
-        rt_map = routing_table_map_;
-    }
-
-    for (auto it = rt_map.begin(); it != rt_map.end();) {
-        it->second->UnInit();
-        it = rt_map.erase(it);
-        TOP_KINFO("remove all service routing table");
-    }
-}
-
 RoutingTablePtr MultiRouting::GetRoutingTable(const uint64_t & type, bool root) {
     if (root || type == kRoot) {
         if (!root_manager_ptr_) {
@@ -126,7 +107,7 @@ RoutingTablePtr MultiRouting::GetRoutingTable(const std::string & routing_id, bo
         if (!root_manager_ptr_) {
             return nullptr;
         }
-        return root_manager_ptr_->GetRoutingTable(routing_id);
+        return root_manager_ptr_->GetRoutingTable(kRoot);
     }
     return GetServiceRoutingTable(routing_id);
 }


### PR DESCRIPTION
1. delete `root_routing_map_` in `root_routing_manager` . It only contains one root_routing_table element.
2. rename `root_manager_ptr->AddRoutingTable` to `root_manager_ptr->InitRootRoutingTable` ( It was confused with `multi_rooting::AddRoutingTable()` )