### PR TITLE
rpc(opt): top4021, ratelimit alarm

### DIFF
--- a/src/xtopcom/xrpc/xhttp/xhttp_server.cpp
+++ b/src/xtopcom/xrpc/xhttp/xhttp_server.cpp
@@ -94,6 +94,9 @@ void xhttp_server::start(uint16_t nPort, uint32_t nThreadNum) {
                 std::string sequence_id = RatelimitServerHelper::GetSequenceId(data_http->content_);
                 char info[256] = {0};
                 snprintf(info, 256, "{\"errmsg\":\"request too often.\",\"errno\":110,\"sequence_id\":\"%s\"}", sequence_id.c_str());
+                XMETRICS_PACKET_ALARM("rpc_ratelimit_alarm",
+                                      "errmsg", "request too often",
+                                      "sequence_id", sequence_id);
                 data_http->response_->write(info);
             }
             delete data_http;

--- a/src/xtopcom/xrpc/xws/xws_server.cpp
+++ b/src/xtopcom/xrpc/xws/xws_server.cpp
@@ -94,6 +94,9 @@ void xws_server::start(uint16_t nPort, uint32_t nThreadNum) {
                 std::string sequence_id = RatelimitServerHelper::GetSequenceId(data_http->content_);
                 char info[256] = {0};
                 snprintf(info, 256, "{\"errmsg\":\"request too often.\",\"errno\":110,\"sequence_id\":\"%s\"}", sequence_id.c_str());
+                XMETRICS_PACKET_ALARM("rpc_ratelimit_alarm",
+                                      "errmsg", "request too often",
+                                      "sequence_id", sequence_id);
                 data_http->connection_->send(info);
             }
             delete data_http;


### PR DESCRIPTION
self test ok  
/tmp/zec1/xtop.2021-08-16-091544-1-31174.log:xbase-09:15:17.111-T2138:[Keyfo]-(metrics_packet_impl:24): [metrics]{"category":"rpc","tag":"ratelimit_alarm","type":"alarm","content":{"errmsg":"request too often","sequence_id":"1"}}