### PR TITLE
opt(rpc): add metric

### DIFF
--- a/src/xtopcom/xmetrics/xmetrics.cpp
+++ b/src/xtopcom/xmetrics/xmetrics.cpp
@@ -411,6 +411,9 @@ char const * matrics_name(xmetircs_tag_t const tag) noexcept {
         RETURN_METRICS_NAME(xevent_major_type_role);
         RETURN_METRICS_NAME(xevent_major_type_blockfetcher);
         RETURN_METRICS_NAME(xevent_major_type_sync);
+    
+        RETURN_METRICS_NAME(rpc_edge_tx_request);
+        RETURN_METRICS_NAME(rpc_edge_query_request);        
 
         default: assert(false); return nullptr;
     }

--- a/src/xtopcom/xmetrics/xmetrics.h
+++ b/src/xtopcom/xmetrics/xmetrics.h
@@ -458,6 +458,10 @@ enum E_SIMPLE_METRICS_TAG : size_t {
     xevent_major_type_sync,
     xevent_end=xevent_major_type_sync,
 
+    // rpc
+    rpc_edge_tx_request,
+    rpc_edge_query_request,
+
     e_simple_total,
 };
 using xmetircs_tag_t = E_SIMPLE_METRICS_TAG;

--- a/src/xtopcom/xrpc/xedge/xedge_rpc_handler_base.hpp
+++ b/src/xtopcom/xrpc/xedge/xedge_rpc_handler_base.hpp
@@ -103,6 +103,7 @@ void xedge_handler_base<T>::edge_send_msg(const std::vector<std::shared_ptr<xrpc
                    dst.to_string().c_str(),
                    msg.hash());
                 vd->forward_broadcast_message(msg, dst);
+                XMETRICS_GAUGE(metrics::rpc_edge_tx_request, msg.payload().size());
             } else {
                 auto count = 0;
                 auto msghash = msg.hash();
@@ -127,8 +128,8 @@ void xedge_handler_base<T>::edge_send_msg(const std::vector<std::shared_ptr<xrpc
                     }
                     ++count;
                 }
+                XMETRICS_GAUGE(metrics::rpc_edge_query_request, msg.payload().size());
             }
-            XMETRICS_COUNTER_INCREMENT("rpc_edge_request", 1);
         } catch (const xrpc_error &e) {
             throw e;
         } catch (top::error::xtop_error_t const & eh) {


### PR DESCRIPTION
/tmp/rec3/xtop.log:xbase-10:56:37.468-T26184:[Keyfo]-(dump:47): [metrics]{"category":"rpc","tag":"edge_query_request","type":"counter","content":{"count":2,"value":488}}    /tmp/rec3/xtop.log:xbase-10:56:37.468-T26184:[Keyfo]-(dump:47): [metrics]{"category":"rpc","tag":"edge_tx_request","type":"counter","content":{"count":2,"value":992}}