### PR TITLE
opt(rpc): tx v2 disabled

### DIFF
--- a/src/xtopcom/xrpc/xrule_manager.cpp
+++ b/src/xtopcom/xrpc/xrule_manager.cpp
@@ -181,7 +181,11 @@ void xfilter_manager::sendTransaction_filter(xjson_proc_t & json_proc) {
     auto & params = json_proc.m_request_json["params"];
 
     auto version = params["tx_structure_version"].asUInt();
+#ifdef RPC_V2
     CONDTION_FAIL_THROW((version == data::xtransaction_version_1) || (version == data::xtransaction_version_2), enum_xrpc_error_code::rpc_param_param_error, "tx_structure_version invalid");
+#else
+    CONDTION_FAIL_THROW((version == data::xtransaction_version_1), enum_xrpc_error_code::rpc_param_param_error, "tx_structure_version invalid");
+#endif
     if (version == data::xtransaction_version_2) {
         CONDTION_FAIL_THROW(params["sender_account"].isString() && !params["sender_account"].asString().empty(),
                             enum_xrpc_error_code::rpc_param_param_lack,

--- a/src/xtopcom/xtxpool_service_v2/src/xtxpool_service.cpp
+++ b/src/xtopcom/xtxpool_service_v2/src/xtxpool_service.cpp
@@ -773,6 +773,12 @@ int32_t xtxpool_service::request_transaction_consensus(const data::xtransaction_
         return xtxpool_v2::xtxpool_error_service_not_running;
     }
 
+#ifndef RPC_V2
+    if (tx->get_tx_version() != xtransaction_version_1) {
+        return xtxpool_v2::xtxpool_error_tx_version_invalid;
+    }
+#endif
+
     int32_t ret = xverifier::xtx_verifier::verify_send_tx_source(tx.get(), local);
     if (ret) {
         xwarn("[global_trace][xtxpool_service]tx=%s,account=%s verify send tx source fail", tx->get_digest_hex_str().c_str(), tx->get_source_addr().c_str());

--- a/src/xtopcom/xtxpool_v2/xtxpool_error.h
+++ b/src/xtopcom/xtxpool_v2/xtxpool_error.h
@@ -34,6 +34,7 @@ enum enum_xtxpool_error_type {
     xtxpool_error_account_not_in_charge,
     xtxpool_error_account_state_fall_behind,
     xtxpool_error_service_not_running,
+    xtxpool_error_tx_version_invalid,
     xtxpool_error_max,
 };
 
@@ -59,7 +60,8 @@ inline std::string xtxpool_error_to_string(int32_t code) {
                                    XTXPOOL_TO_STR(xtxpool_error_tx_invalid_type),
                                    XTXPOOL_TO_STR(xtxpool_error_account_not_in_charge),
                                    XTXPOOL_TO_STR(xtxpool_error_account_state_fall_behind),
-                                   XTXPOOL_TO_STR(xtxpool_error_service_not_running)};
+                                   XTXPOOL_TO_STR(xtxpool_error_service_not_running),
+                                   XTXPOOL_TO_STR(xtxpool_error_tx_version_invalid)};
 
     return names[code - xtxpool_error_base - 1];
 }


### PR DESCRIPTION
edge rejection:  
{  
   "errmsg" : "tx_structure_version invalid",  
   "errno" : 1,  
   "sequence_id" : "2"  
}  

consensus node rejection:  
/tmp/con5/xtop.2021-11-18-100221-1-43231.log:xbase-10:02:13.610-T153681920:[Keyfo]-(cluster_process_request:112): [global_trace][advance_rpc][recv edge msg][push unit_service] tx hash: 784a3f8b9d57ea67528d8c1ef0003b50fbd301eebd5a6940d8790a59a02915dd,T8000037d4fbc08bf4513a68a287ed218b0adbd497ef30,src edge.group/760000ff1e0407ff/T00000LNi53Ub726HcPXZfC4z6zLgTo5ks6GzTUp/2/18446744073709551615/14/1,dst consensus.auditor.group/760000ff000407ff/T00000Lgv7jLC3DQ3i3guTVLEVhGaStR4RaUJVwA/1/1/4/4,aaf02195fef95d7a ignored