### PR TITLE
💡 remove ci cancel-in-progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ on:
       - dev/**
       - release/**
 
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     if: github.repository_owner == 'telosprotocol' && (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' || github.event_name == 'pushed')


### PR DESCRIPTION
#### what this used for?

[github action doc](https://docs.github.com/en/actions/using-jobs/using-concurrency)

#### why remove this?

For now, `cancel-in-progress` use `SIGKILL` to terminate process, which might leave uncompleted compilation files (`xxx.cpp.o` for example).
Then when running next job, if this `xxx.cpp` file not changed, CMake skip recompile `xxx.cpp.o`, and cause link error after.

> [first action](https://github.com/telosprotocol/TOP-chain/actions/runs/3318609764/jobs/5482746396#step:5:611) cancel in first run while compiling `xws_server.cpp.o`:

``` Text
[ 89%] Building CXX object src/xtopcom/xrpc/CMakeFiles/xrpc.dir/xws/xws_server.cpp.o
Error: The operation was canceled.
```

> [next action](https://github.com/telosprotocol/TOP-chain/actions/runs/3318697969/jobs/5482936744#step:5:284) failed to link librpc.a:

``` Text
/usr/include/c++/4.8.2/ext/new_allocator.h:120: undefined reference to `top::xrpc::xws_server::xws_server(std::shared_ptr<top::xrpc::xrpc_edge_vhost>, top::xtop_extended<top::common::xtop_ip>, bool, top::observer_ptr<top::base::xvblockstore_t>, top::observer_ptr<top::base::xvtxstore_t>, top::observer_ptr<top::elect::MultilayerNetwork>, top::observer_ptr<top::election::cache::xtop_data_accessor_face> const&)'
../../lib/Linux/libxrpc.a(xrpc_init.cpp.o): In function `void __gnu_cxx::new_allocator<top::xrpc::xws_server>::destroy<top::xrpc::xws_server>(top::xrpc::xws_server*)':
/usr/include/c++/4.8.2/ext/new_allocator.h:124: undefined reference to `top::xrpc::xws_server::~xws_server()'
```

---

more infomation reference: [discussion](https://github.com/orgs/community/discussions/26311)

Since we are already trying to use incremental build, avoid same PR concurrency will not save that much time. And we can still cancel repeated actions manually.