### PR TITLE
remove deprecated default space keystore pswd

### DIFF
--- a/src/xtopcom/xtopcl/src/api_method.cpp
+++ b/src/xtopcom/xtopcl/src/api_method.cpp
@@ -32,19 +32,6 @@ using std::ifstream;
 using std::ostringstream;
 static const std::string SAFEBOX_ENDPOINT_ENV = "SAFEBOX_ENDPOINT";
 
-// #[deprecated]
-static const std::string DEPRECATED_OLD_DEFAULT_KEY = " ";
-
-// local test
-// #define NEXT_VERSION
-#ifdef NEXT_VERSION
-#    define __compatibility_begin(...) if (false) {
-#    define __compatibility_end(...) }
-#else
-#    define __compatibility_begin(...)
-#    define __compatibility_end(...)
-#endif
-
 bool check_pri_key(const std::string & str_pri) {
     return BASE64_PRI_KEY_LEN == str_pri.size() || HEX_PRI_KEY_LEN == str_pri.size();
 }
@@ -385,45 +372,28 @@ void ApiMethod::set_default_account(const std::string & account, const string & 
 
     std::string pri_key;
     std::string kdf_key;
-    __compatibility_begin("try old empty_pw \" \" ");
-    if (decrypt_keystore_by_password(DEPRECATED_OLD_DEFAULT_KEY, keystore_info, pri_key) == false) {
-        // " " password not right.
-    } else {
-        xassert(!pri_key.empty());
-        std::cout << "It is recommended to set a password to protect the keystore file!" << std::endl;
-        // continue to set default.
-        if (decrypt_get_kdf_key(DEPRECATED_OLD_DEFAULT_KEY, keystore_info, kdf_key) == false) {
-            xassert(false);  // not possible.
-            return;
-        }
-    }
-    if (pri_key.empty()) {
-        __compatibility_end();
-        std::string pw;
-        if (pw_path.empty()) {
-            std::cout << "Please input password." << std::endl;
-            pw = input_hiding();
-        } else {
-            auto result = get_password(keystore_type::account_key, password_type::file_path, pw_path);
-            if (result.first == false) {
-                return;
-            } else {
-                pw = result.second;
-            }
-        }
-        if (decrypt_keystore_by_password(pw, keystore_info, pri_key) == false) {
-            // password not right.
-            out_str << "Wrong password, set default account failed." << get_keystore_hint(keystore_info) << std::endl;
-            return;
-        }
-        if (decrypt_get_kdf_key(pw, keystore_info, kdf_key) == false) {
-            xassert(false);  // not possible.
-            return;
-        }
 
-        __compatibility_begin("try old empty_pw \" \" ");
+    std::string pw;
+    if (pw_path.empty()) {
+        std::cout << "Please input password." << std::endl;
+        pw = input_hiding_no_empty("Password not allow to be empty!");
+    } else {
+        auto result = get_password(keystore_type::account_key, password_type::file_path, pw_path);
+        if (result.first == false) {
+            return;
+        } else {
+            pw = result.second;
+        }
     }
-    __compatibility_end();
+    if (decrypt_keystore_by_password(pw, keystore_info, pri_key) == false) {
+        // password not right.
+        out_str << "Wrong password, set default account failed." << get_keystore_hint(keystore_info) << std::endl;
+        return;
+    }
+    if (decrypt_get_kdf_key(pw, keystore_info, kdf_key) == false) {
+        xassert(false);  // not possible.
+        return;
+    }
 
     if (!pri_key.empty() && set_prikey_to_daemon(account, kdf_key, out_str) == 0) {
         out_str << "Set default account successfully." << std::endl;
@@ -459,33 +429,16 @@ void ApiMethod::reset_keystore_password(std::string & public_key, std::ostringst
 
     std::string pri_key;
 
-    std::cout << "Please input old password. [If the keystore has no password, press Enter directly.(empty password will be deprecated soon)]" << std::endl;
-    // COMPATIBILITY:
-    auto pw = input_hiding();
-    __compatibility_begin("temporarily allow empty password to reset. if old_pw == empty, try \" \" ");
-    if (pw.empty()) {
-        if (decrypt_keystore_by_password(DEPRECATED_OLD_DEFAULT_KEY, keystore_info, pri_key) == false) {
-            // " " password not right.
-        } else {
-            std::cout << "It is recommended to set a password to protect the keystore file!" << std::endl;
-            xassert(!pri_key.empty());
-            // continue to reset password.
-        }
+    std::cout << "Please input old password." << std::endl;
+
+    auto pw = input_hiding_no_empty("Password not allow to be empty!");
+    if (decrypt_keystore_by_password(pw, keystore_info, pri_key) == false) {
+        // password not right.
+        out_str << "Old password wrong," << get_keystore_hint(keystore_info) << std::endl;
+        // out_str << 
+        out_str << "Reset password failed." << std::endl;
+        return;
     }
-    if (pri_key.empty()) {
-        __compatibility_end();
-        // TODO NEXT_NEXT_VERSION can uncomments: or not , not a big deal.
-        // auto pw = input_hiding_no_empty("Password not allow to be empty!");
-        if (decrypt_keystore_by_password(pw, keystore_info, pri_key) == false) {
-            // password not right.
-            out_str << "Old password wrong," << get_keystore_hint(keystore_info) << std::endl;
-            // out_str << 
-            out_str << "Reset password failed." << std::endl;
-            return;
-        }
-        __compatibility_begin("temporarily allow empty password to reset. if old_pw == empty, try \" \" ");
-    }
-    __compatibility_end();
 
     std::string new_password;
     // keystore type is not import here. whatever.
@@ -557,26 +510,14 @@ void ApiMethod::export_account(const std::string & account, std::ostringstream &
         }
 
         std::string pri_key;
-        __compatibility_begin("try old empty_pw \" \" ");
-        if (decrypt_keystore_by_password(DEPRECATED_OLD_DEFAULT_KEY, keystore_info, pri_key) == false) {
-            // " " password not right.
-        } else {
-            std::cout << "It is recommended to set a password to protect the keystore file!" << std::endl;
-            xassert(!pri_key.empty());
+        std::string pw;
+        std::cout << "Please input password." << std::endl;
+        pw = input_hiding_no_empty("Password not allow to be empty!");
+        if (decrypt_keystore_by_password(pw, keystore_info, pri_key) == false) {
+            // password not right.
+            out_str << "Wrong password, export account failed." << get_keystore_hint(keystore_info) << std::endl;
+            return;
         }
-        if (pri_key.empty()) {
-            __compatibility_end();
-            std::string pw;
-            std::cout << "Please input password." << std::endl;
-            pw = input_hiding();
-            if (decrypt_keystore_by_password(pw, keystore_info, pri_key) == false) {
-                // password not right.
-                out_str << "Wrong password, export account failed." << get_keystore_hint(keystore_info) << std::endl;
-                return;
-            }
-            __compatibility_begin("try old empty_pw \" \" ");
-        }
-        __compatibility_end();
 
         out_str << "Export successfully.\n" << std::endl;
         out_str << "Keystore file: " << keystore_file << std::endl;
@@ -661,26 +602,8 @@ int ApiMethod::set_default_miner(const std::string & pub_key, const std::string 
 
         password = result.second;
     } else {
-        // in compatibility mode (no password file path specified)
-        // first try to decrypt keystore with deprecated password. if it works, it means that user hasn't set password yet.
-        // if deprecated password fails to work, ask user to input password.
-
-        if (decrypt_keystore_by_password(DEPRECATED_OLD_DEFAULT_KEY, keystore_info, pri_key) == false) {
-            // " " password not right.
-        } else {
-            xassert(!pri_key.empty());
-            std::cout << "It is recommended to set a password to protect the keystore file!" << std::endl;
-            // continue to set default.
-            if (decrypt_get_kdf_key(DEPRECATED_OLD_DEFAULT_KEY, keystore_info, kdf_key) == false) {
-                xassert(false);  // not possible.
-                return -1;
-            }
-        }
-
-        pri_key.clear();
-
         std::cout << "Please input password." << std::endl;
-        password = input_hiding();
+        password = input_hiding_no_empty("Password not allow to be empty!");
     }
 
     if (decrypt_keystore_by_password(password, keystore_info, pri_key) == false) {
@@ -693,45 +616,6 @@ int ApiMethod::set_default_miner(const std::string & pub_key, const std::string 
         xassert(false);  // not possible.
         return -1;
     }
-    //__compatibility_begin("try old empty_pw \" \" ");
-    //if (decrypt_keystore_by_password(DEPRECATED_OLD_DEFAULT_KEY, keystore_info, pri_key) == false) {
-    //    // " " password not right.
-    //} else {
-    //    std::cout << "It is recommended to set a password to protect the keystore file!" << std::endl;
-    //    xassert(!pri_key.empty());
-    //    // continue to set default.
-    //    if (decrypt_get_kdf_key(DEPRECATED_OLD_DEFAULT_KEY, keystore_info, kdf_key) == false) {
-    //        xassert(false);  // not possible.
-    //        return -1;
-    //    }
-    //}
-    //if (pri_key.empty()) {
-    //    __compatibility_end();
-    //    std::string pw;
-    //    if (pw_path.empty()) {
-    //        std::cout << "Please input password." << std::endl;
-    //        pw = input_hiding();
-    //    } else {
-    //        auto result = get_password(keystore_type::account_key, password_type::file_path, pw_path);
-    //        if (result.first == false) {
-    //            return -1;
-    //        } else {
-    //            pw = result.second;
-    //        }
-    //    }
-    //    if (decrypt_keystore_by_password(pw, keystore_info, pri_key) == false) {
-    //        // password not right.
-    //        out_str << "Wrong password, set default miner failed." << get_keystore_hint(keystore_info) << std::endl;
-    //        return -1;
-    //    }
-    //    if (decrypt_get_kdf_key(pw, keystore_info, kdf_key) == false) {
-    //        xassert(false);  // not possible.
-    //        return -1;
-    //    }
-
-    //    __compatibility_begin("try old empty_pw \" \" ");
-    //}
-    //__compatibility_end();
 
     if (pri_key.empty() || kdf_key.empty()) {
         out_str << "decrypt private token failed" << std::endl;


### PR DESCRIPTION
clean up the default `" "` keystore password compatibility logic.
fix bug ID1002718